### PR TITLE
chore: change go.mod to go 1.23 for one more release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/specterops/dawgs
 
-go 1.24.0
+go 1.23.0
 
 require (
 	cuelang.org/go v0.13.2


### PR DESCRIPTION
Modsync while I was working on go 1.24 caused dawgs to require 1.24. This is currently unnecessary and causing issues for BloodHound v7.6.0. Downgrading for now.