### PR TITLE
BED-6358 Scalar support

### DIFF
--- a/cypher/models/cypher/functions.go
+++ b/cypher/models/cypher/functions.go
@@ -19,6 +19,10 @@ const (
 	ListSizeFunction           = "size"
 	CoalesceFunction           = "coalesce"
 	CollectFunction            = "collect"
+	SumFunction                = "sum"
+	AvgFunction                = "avg"
+	MinFunction                = "min"
+	MaxFunction                = "max"
 
 	// ITTC - Instant Type; Temporal Component (https://neo4j.com/docs/cypher-manual/current/functions/temporal/)
 	ITTCYear              = "year"

--- a/cypher/models/pgsql/format/format.go
+++ b/cypher/models/pgsql/format/format.go
@@ -655,6 +655,11 @@ func formatTableAlias(builder *OutputBuilder, tableAlias pgsql.TableAlias) error
 }
 
 func formatCommonTableExpressions(builder *OutputBuilder, commonTableExpressions pgsql.With) error {
+	// Only write "with" if there are actually expressions
+	if len(commonTableExpressions.Expressions) == 0 {
+		return nil
+	}
+
 	builder.Write("with ")
 
 	if commonTableExpressions.Recursive {

--- a/cypher/models/pgsql/functions.go
+++ b/cypher/models/pgsql/functions.go
@@ -15,6 +15,8 @@ const (
 	FunctionArrayRemove              Identifier = "array_remove"
 	FunctionMin                      Identifier = "min"
 	FunctionMax                      Identifier = "max"
+	FunctionSum                      Identifier = "sum"
+	FunctionAvg                      Identifier = "avg"
 	FunctionLocalTimestamp           Identifier = "localtimestamp"
 	FunctionLocalTime                Identifier = "localtime"
 	FunctionCurrentTime              Identifier = "current_time"
@@ -34,7 +36,7 @@ const (
 
 func IsAggregateFunction(function Identifier) bool {
 	switch function {
-	case FunctionCount, FunctionArrayAggregate:
+	case FunctionCount, FunctionArrayAggregate, FunctionMin, FunctionMax, FunctionSum, FunctionAvg:
 		return true
 
 	default:

--- a/cypher/models/pgsql/test/testcase.go
+++ b/cypher/models/pgsql/test/testcase.go
@@ -169,7 +169,12 @@ func (s *TranslationTestCase) Assert(t *testing.T, expectedSQL string, kindMappe
 		} else if formattedQuery, err := translate.Translated(translation); err != nil {
 			t.Fatalf("Failed to format SQL translatedQuery: %v", err)
 		} else {
-			require.Equalf(t, expectedSQL, formattedQuery, "Test case for cypher query: '%s' failed to match.", s.Cypher)
+			// Apply same whitespace normalization as expected SQL (from file parsing)
+			normalizedActual, err := regexp.ReplaceAll("\\s+", strings.TrimSpace(formattedQuery), " ")
+			if err != nil {
+				t.Fatalf("error while attempting to collapse whitespace in actual query: %v", err)
+			}
+			require.Equalf(t, expectedSQL, normalizedActual, "Test case for cypher query: '%s' failed to match.", s.Cypher)
 
 			if s.PgSQLParams != nil {
 				require.Equal(t, s.PgSQLParams, translation.Parameters)

--- a/cypher/models/pgsql/test/translation_cases/scalar_aggregation.sql
+++ b/cypher/models/pgsql/test/translation_cases/scalar_aggregation.sql
@@ -29,3 +29,12 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from
 -- Multiple aggregates (no GROUP BY needed)
 -- case: MATCH (n) RETURN count(n), sum(n.age), avg(n.age), min(n.age), max(n.age)
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select count(s0.n0)::int8, sum(((s0.n0).properties ->> 'age'))::numeric, avg(((s0.n0).properties ->> 'age'))::numeric, min(((s0.n0).properties ->> 'age')), max(((s0.n0).properties ->> 'age')) from s0;
+
+-- Pure scalar queries (no MATCH clause needed)
+select 42;
+
+-- case: RETURN 'hello world'
+select 'hello world';
+
+-- case: RETURN 2 + 3
+select 2 + 3;

--- a/cypher/models/pgsql/test/translation_cases/scalar_aggregation.sql
+++ b/cypher/models/pgsql/test/translation_cases/scalar_aggregation.sql
@@ -1,0 +1,31 @@
+-- Test cases for scalar aggregation functions with GROUP BY support
+-- Tests verify the new aggregate functions (sum, avg, min, max) work correctly
+-- and that GROUP BY clauses are properly generated for mixed scalar/aggregate queries
+
+-- Simple sum aggregate
+-- case: MATCH (n) RETURN sum(n.age)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select sum(((s0.n0).properties ->> 'age'))::numeric from s0;
+
+-- Simple average aggregate  
+-- case: MATCH (n) RETURN avg(n.salary)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select avg(((s0.n0).properties ->> 'salary'))::numeric from s0;
+
+-- Simple min aggregate
+-- case: MATCH (n) RETURN min(n.created_date)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select min(((s0.n0).properties ->> 'created_date')) from s0;
+
+-- Simple max aggregate
+-- case: MATCH (n) RETURN max(n.updated_date)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select max(((s0.n0).properties ->> 'updated_date')) from s0;
+
+-- Sum with GROUP BY (single property)
+-- case: MATCH (n) RETURN n.department, sum(n.salary)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select ((s0.n0).properties -> 'department'), sum(((s0.n0).properties ->> 'salary'))::numeric from s0 group by ((s0.n0).properties -> 'department');
+
+-- Average with GROUP BY (single property)
+-- case: MATCH (n) RETURN n.department, avg(n.age)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select ((s0.n0).properties -> 'department'), avg(((s0.n0).properties ->> 'age'))::numeric from s0 group by ((s0.n0).properties -> 'department');
+
+-- Multiple aggregates (no GROUP BY needed)
+-- case: MATCH (n) RETURN count(n), sum(n.age), avg(n.age), min(n.age), max(n.age)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select count(s0.n0)::int8, sum(((s0.n0).properties ->> 'age'))::numeric, avg(((s0.n0).properties ->> 'age'))::numeric, min(((s0.n0).properties ->> 'age')), max(((s0.n0).properties ->> 'age')) from s0;

--- a/cypher/models/pgsql/test/translation_cases/scalar_aggregation.sql
+++ b/cypher/models/pgsql/test/translation_cases/scalar_aggregation.sql
@@ -38,3 +38,40 @@ select 'hello world';
 
 -- case: RETURN 2 + 3
 select 2 + 3;
+
+-- COLLECT function tests with GROUP BY support
+-- case: MATCH (n) RETURN n.department, collect(n.name)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select ((s0.n0).properties -> 'department'), array_remove(coalesce(array_agg(((s0.n0).properties ->> 'name'))::anyarray, array []::text[])::anyarray, null)::anyarray from s0 group by ((s0.n0).properties -> 'department');
+
+-- case: MATCH (n) RETURN collect(n.name)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select array_remove(coalesce(array_agg(((s0.n0).properties ->> 'name'))::anyarray, array []::text[])::anyarray, null)::anyarray from s0;
+
+-- case: MATCH (n) RETURN n.department, collect(n.name), count(n)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select ((s0.n0).properties -> 'department'), array_remove(coalesce(array_agg(((s0.n0).properties ->> 'name'))::anyarray, array []::text[])::anyarray, null)::anyarray, count(s0.n0)::int8 from s0 group by ((s0.n0).properties -> 'department');
+
+-- SIZE function tests with different array types
+-- case: MATCH (n) RETURN size(n.tags)
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select jsonb_array_length(((s0.n0).properties -> 'tags'))::int from s0;
+
+-- case: MATCH (n) RETURN size(collect(n.name))
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select array_length(array_remove(coalesce(array_agg(((s0.n0).properties ->> 'name'))::anyarray, array []::text[])::anyarray, null)::anyarray, 1)::int from s0;
+
+-- case: MATCH (n) WHERE size(n.permissions) > 2 RETURN n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where (jsonb_array_length((n0.properties -> 'permissions'))::int > 2)) select s0.n0 as n from s0;
+
+-- Complex COLLECT + SIZE interaction from next-steps.md
+-- case: MATCH (n) WITH n, collect(n.prop) as props WHERE size(props) > 1 RETURN n, props
+with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s1.n0 as n0, array_remove(coalesce(array_agg(((s1.n0).properties ->> 'prop'))::anyarray, array []::text[])::anyarray, null)::anyarray as i0 from s1 group by n0) select s0.n0 as n, s0.i0 as props from s0 where (array_length(s0.i0, 1)::int > 1);
+
+-- WITH statement + aggregate testing (supported patterns)
+-- case: MATCH (n) WITH n, count(n) as node_count WHERE node_count > 1 RETURN n, node_count
+with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s1.n0 as n0, count(s1.n0)::int8 as i0 from s1 group by n0) select s0.n0 as n, s0.i0 as node_count from s0 where (s0.i0 > 1);
+
+-- case: MATCH (n) WITH sum(n.age) as total_age, count(n) as total_count RETURN total_age / total_count as avg_age
+with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select sum(((s1.n0).properties ->> 'age'))::numeric as i0, count(s1.n0)::int8 as i1 from s1) select s0.i0 / s0.i1 as avg_age from s0;
+
+-- case: MATCH (n) WITH count(n) as cnt WHERE cnt > 1 RETURN cnt
+with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select count(s1.n0)::int8 as i0 from s1) select s0.i0 as cnt from s0 where (s0.i0 > 1);
+
+-- case: MATCH (n) WITH count(n) as lim MATCH (o) RETURN o
+with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select count(s1.n0)::int8 as i0 from s1), s2 as (select s0.i0 as i0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1 from s0, node n1) select s2.n1 as o from s2;

--- a/cypher/models/pgsql/translate/function.go
+++ b/cypher/models/pgsql/translate/function.go
@@ -276,6 +276,56 @@ func (s *Translator) translateFunction(typedExpression *cypher.FunctionInvocatio
 			)
 		}
 
+	case cypher.SumFunction:
+		if typedExpression.NumArguments() != 1 {
+			s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
+		} else if argument, err := s.treeTranslator.PopOperand(); err != nil {
+			s.SetError(err)
+		} else {
+			s.treeTranslator.PushOperand(pgsql.FunctionCall{
+				Function:   pgsql.FunctionSum,
+				Parameters: []pgsql.Expression{argument},
+				CastType:   pgsql.Numeric,
+			})
+		}
+
+	case cypher.AvgFunction:
+		if typedExpression.NumArguments() != 1 {
+			s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
+		} else if argument, err := s.treeTranslator.PopOperand(); err != nil {
+			s.SetError(err)
+		} else {
+			s.treeTranslator.PushOperand(pgsql.FunctionCall{
+				Function:   pgsql.FunctionAvg,
+				Parameters: []pgsql.Expression{argument},
+				CastType:   pgsql.Numeric,
+			})
+		}
+
+	case cypher.MinFunction:
+		if typedExpression.NumArguments() != 1 {
+			s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
+		} else if argument, err := s.treeTranslator.PopOperand(); err != nil {
+			s.SetError(err)
+		} else {
+			s.treeTranslator.PushOperand(pgsql.FunctionCall{
+				Function:   pgsql.FunctionMin,
+				Parameters: []pgsql.Expression{argument},
+			})
+		}
+
+	case cypher.MaxFunction:
+		if typedExpression.NumArguments() != 1 {
+			s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
+		} else if argument, err := s.treeTranslator.PopOperand(); err != nil {
+			s.SetError(err)
+		} else {
+			s.treeTranslator.PushOperand(pgsql.FunctionCall{
+				Function:   pgsql.FunctionMax,
+				Parameters: []pgsql.Expression{argument},
+			})
+		}
+
 	default:
 		s.SetErrorf("unknown cypher function: %s", typedExpression.Name)
 	}


### PR DESCRIPTION
  Summary
  - Implement GROUP BY clause generation for mixed scalar/aggregate RETURN queries
  - Add support for missing aggregate functions: sum(), avg(), min(), max()
  - Add support for pure scalar queries (queries without MATCH clauses like RETURN 42)
  - Verify GROUP BY is correctly generated when mixing scalar properties with aggregates
  - Test all new aggregate functions work with numeric casting where appropriate
  - Confirm scalar queries execute without generating invalid SQL
  - Test cases added in scalar_aggregation.sql covering all scenarios
  
There was AI helping me navigate some of the complex parts around the group by logic. I think I understand it, but I would like specific attention paid to the projections.go part. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for aggregate functions: sum, avg, min, max.
  - Automatic GROUP BY generation when aggregates mix with non-aggregate fields.
  - Tail projections omit a FROM clause when there is no source binding.

- Bug Fixes
  - Avoids emitting an empty WITH clause when no common table expressions exist.

- Tests
  - Added scalar and grouped aggregation test cases.
  - Normalized whitespace in SQL comparisons to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->