### PR TITLE
(chore): Change to use a shared connection string for simplicity testing PQE-411

### DIFF
--- a/integration/cypher_test.go
+++ b/integration/cypher_test.go
@@ -92,7 +92,10 @@ func TestCypher(t *testing.T) {
 
 	db, ctx := SetupDB(t, datasetNames...)
 
-	driver := *driverFlag
+	driver, err := driverFromConnStr(os.Getenv("CONNECTION_STRING"))
+	if err != nil {
+		t.Fatalf("Failed to detect driver: %v", err)
+	}
 
 	for _, g := range groups {
 		ClearGraph(t, db, ctx)

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -31,15 +32,29 @@ import (
 	"github.com/specterops/dawgs/opengraph"
 	"github.com/specterops/dawgs/util/size"
 
-	// Register drivers
-	_ "github.com/specterops/dawgs/drivers/neo4j"
+	"github.com/specterops/dawgs/drivers/neo4j"
 )
 
 var (
-	driverFlag       = flag.String("driver", "pg", "database driver to test against (pg, neo4j)")
-	connStrFlag      = flag.String("connection", "", "database connection string (overrides PG_CONNECTION_STRING env var)")
 	localDatasetFlag = flag.String("local-dataset", "", "name of a local dataset to test (e.g. local/phantom)")
 )
+
+// driverFromConnStr returns the dawgs driver name based on the connection string scheme.
+func driverFromConnStr(connStr string) (string, error) {
+	u, err := url.Parse(connStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	switch u.Scheme {
+	case "postgresql", "postgres":
+		return pg.DriverName, nil
+	case neo4j.DriverName, "neo4j+s", "neo4j+ssc":
+		return neo4j.DriverName, nil
+	default:
+		return "", fmt.Errorf("unknown connection string scheme %q", u.Scheme)
+	}
+}
 
 // SetupDB opens a database connection for the selected driver, asserts a schema
 // derived from the given datasets, and registers cleanup. Returns the database
@@ -49,12 +64,14 @@ func SetupDB(t *testing.T, datasets ...string) (graph.Database, context.Context)
 
 	ctx := context.Background()
 
-	connStr := *connStrFlag
+	connStr := os.Getenv("CONNECTION_STRING")
 	if connStr == "" {
-		connStr = os.Getenv("PG_CONNECTION_STRING")
+		t.Fatal("CONNECTION_STRING env var is not set")
 	}
-	if connStr == "" {
-		t.Fatal("no connection string: set -connection flag or PG_CONNECTION_STRING env var")
+
+	driver, err := driverFromConnStr(connStr)
+	if err != nil {
+		t.Fatalf("Failed to detect driver: %v", err)
 	}
 
 	cfg := dawgs.Config{
@@ -62,8 +79,7 @@ func SetupDB(t *testing.T, datasets ...string) (graph.Database, context.Context)
 		ConnectionString:      connStr,
 	}
 
-	// PG needs a pool with composite type registration
-	if *driverFlag == pg.DriverName {
+	if driver == pg.DriverName {
 		pool, err := pg.NewPool(connStr)
 		if err != nil {
 			t.Fatalf("Failed to create PG pool: %v", err)
@@ -71,7 +87,7 @@ func SetupDB(t *testing.T, datasets ...string) (graph.Database, context.Context)
 		cfg.Pool = pool
 	}
 
-	db, err := dawgs.Open(ctx, *driverFlag, cfg)
+	db, err := dawgs.Open(ctx, driver, cfg)
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)
 	}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly explain the change and its motivation. -->

Resolves: PQE-411

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual integration tests run (`go test -tags manual_integration ./integration/...`)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [ ] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated test configuration to use environment variables instead of CLI flags for database connection settings.
  * Driver type is now automatically detected from the `CONNECTION_STRING` environment variable, eliminating the need for manual flag specification during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->