### PR TITLE
feat (pg): introduce edge start/end with kind filter index - BED-7853

### DIFF
--- a/drivers/pg/query/sql/schema_up.sql
+++ b/drivers/pg/query/sql/schema_up.sql
@@ -107,8 +107,8 @@ create table if not exists node
 alter table node
   alter column properties set storage main;
 
--- Index on the graph ID of each node.
-create index if not exists node_graph_id_index on node using btree (graph_id);
+-- Remove the old graph ID index.
+drop index if exists node_graph_id_index;
 
 -- Index node kind IDs so that lookups by kind is accelerated.
 create index if not exists node_kind_ids_index on node using gin (kind_ids);
@@ -176,8 +176,8 @@ execute procedure delete_node_edges();
 alter table edge
   alter column properties set storage main;
 
--- Index on the graph ID of each edge.
-create index if not exists edge_graph_id_index on edge using btree (graph_id);
+-- Remove the old graph ID index.
+drop index if exists edge_graph_id_index;
 
 -- Index on the start vertex of each edge.
 create index if not exists edge_start_id_index on edge using btree (start_id);
@@ -187,6 +187,11 @@ create index if not exists edge_end_id_index on edge using btree (end_id);
 
 -- Index on the kind of each edge.
 create index if not exists edge_kind_index on edge using btree (kind_id);
+
+-- Index lookups that include the edge's start or end id along with a filter for the edge type. This is the most
+-- common join filter during traversal.
+create index if not exists edge_start_kind_index on edge using btree (start_id, kind_id);
+create index if not exists edge_end_kind_index on edge using btree (end_id, kind_id);
 
 -- Path composite type
 do


### PR DESCRIPTION
## Description

Introduce an index that accelerates `start_id` and `kind_id` filters for edge lookups. This is one of the most common lookups during traversal.

This includes some over-eager index removal that are only adding to the write-amplification problem. The `graph_id` indexes are covered by the `graph_id` column being part of the partition key.

Resolves: BED-7853

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual integration tests run (`go test -tags manual_integration ./integration/...`)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized database query performance to speed up multi-criteria filtering and retrieval.
  * Users should notice snappier responses when performing searches and viewing related data, improving overall application responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->