### PR TITLE
fix: Fix neo4j driver.FetchKinds() not returning edge kinds - BED-8058

### DIFF
--- a/drivers/neo4j/driver.go
+++ b/drivers/neo4j/driver.go
@@ -162,6 +162,20 @@ func (s *driver) FetchKinds(ctx context.Context) (graph.Kinds, error) {
 				}
 			}
 		}
+
+		if result := tx.Raw("CALL db.relationshipTypes()", nil); result.Error() != nil {
+			return result.Error()
+		} else {
+			for result.Next() {
+				var kind string
+				if err := result.Scan(&kind); err != nil {
+					return err
+				} else {
+					kinds = append(kinds, graph.StringKind(kind))
+				}
+			}
+		}
+
 		return nil
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Fixes neo4j driver.FetchKinds() not returning edge kinds

Resolves: BED-8058

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual integration tests run (`go test -tags manual_integration ./integration/...`)

## Screenshots (if appropriate):

FetchKinds now returns edge kinds as well!

<img width="758" height="365" alt="image" src="https://github.com/user-attachments/assets/d3b0d197-ecca-4e5d-b744-d6752eff6bad" />

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [x] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Neo4j driver now retrieves and includes relationship types alongside labels when fetching available kinds from the database, providing a more complete view of your graph structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->