### PR TITLE
chore(dawgrun): agnostic connections and opengraph commands

### DIFF
--- a/tools/dawgrun/README.md
+++ b/tools/dawgrun/README.md
@@ -29,8 +29,8 @@
 `DAWGS` and the data structures it produces.
 
 It currently runs as a REPL for introspecting a `DAWGS`-compatible
-Postgres graph, parsing and translating Cypher queries, and executing
-queries against a live connection.
+graph backend (Postgres or Neo4j), parsing and translating Cypher
+queries, and executing queries against a live connection.
 
 ## Building
 
@@ -64,17 +64,21 @@ The REPL supports command-name completion with `Tab`; ambiguous matches render a
 Available commands:
 
 ```
+    copy-opengraph                  Copies all graph data from one connection to another
     exit                            Quit
     explain-psql                    Explains a translated query over an active PG connection
     help                            This help message, but also more detailed help for individual commands
+    list-connections                Lists currently open named connections
+    load-opengraph                  Loads an OpenGraph JSON file into a connection
     load-db-kinds                   Loads/shows the kind mapping from the specified DB into the 'active set'
     lookup-kind                     Looks up a kind from database based on kind name
     lookup-kind-id                  Looks up a kind from database based on kind ID
-    open-pg-db                      Connects to a specified DAWGS-compatible Postgres DB to do graph introspection.
+    open                            Connects to a named DAWGS-compatible backend using a connection string.
     parse                           Parses and dumps a Cypher query to AST form.
     query-cypher                    Executes a Cypher query and renders table or JSON output
     quit                            Quit
     runtime-trace                   Manage runtime tracing
+    save-opengraph                  Dumps all data from a connection as OpenGraph JSON
     translate-psql                  Parses a query and converts it to the underlying PostgreSQL query
 ```
 
@@ -84,6 +88,10 @@ Most commands that touch a database take a connection _name_ as their
 first argument. Names are assigned when you open the connection and
 are reused for the remainder of the session. The bottom-right status
 widget shows the current number of open connections.
+
+To list their names directly:
+
+    dawgrun > list-connections
 
 A "kind map" is the mapping between a graph's kind names (e.g.
 `User`, `Group`) and the numeric IDs they are stored under in
@@ -95,13 +103,21 @@ and dumps the result.
 
 ## Examples
 
-### Open a Postgres connection
+### Open a backend connection
 
-    dawgrun > open-pg-db local "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable"
-    Opened connection 'local': postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable
+    dawgrun > open local "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable"
+    Opened pg connection 'local'
 
 The first argument (`local`) is the name other commands will refer
-to; the second is any DAWGS-compatible Postgres connection string.
+to; the second is a DAWGS-compatible connection string. The backend
+driver is inferred from the connection string scheme:
+
+- `postgres` / `postgresql` -> `pg`
+- `neo4j` -> `neo4j`
+
+If needed, you can override autodetection with `-driver`:
+
+    dawgrun > open -driver neo4j local "neo4j://neo4j:password@localhost:7687"
 
 ### Inspect kinds
 
@@ -118,6 +134,27 @@ Resolve a kind name to its numeric ID:
 
     dawgrun > lookup-kind-id local 3
     Kind ID 3 => User
+
+### Save, load, and copy OpenGraph data
+
+Dump a connection's full graph as highlighted OpenGraph JSON in the console:
+
+    dawgrun > save-opengraph local
+
+Write it to a file instead:
+
+    dawgrun > save-opengraph -out graph.json local
+    Wrote 12345 nodes and 67890 edges to graph.json
+
+Load an OpenGraph file into a target connection:
+
+    dawgrun > load-opengraph local graph.json
+    Loaded 12345 nodes and 67890 edges from graph.json into connection 'local'
+
+Copy the full graph from one active connection to another:
+
+    dawgrun > copy-opengraph source target
+    Copied 12345 nodes and 67890 edges from connection 'source' to connection 'target'
 
 ### Parse a Cypher query to AST
 

--- a/tools/dawgrun/cmd/dawgrun/main.go
+++ b/tools/dawgrun/cmd/dawgrun/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/google/shlex"
 	repl "github.com/specterops/go-repl"
 
@@ -30,6 +31,9 @@ var (
 )
 
 func main() {
+	// Configure spew's display options
+	spew.Config.DisablePointerAddresses = true
+
 	fmt.Printf("\n%s\n%s",
 		art,
 		bannerStyle.Render(banner),

--- a/tools/dawgrun/docs/RFC.md
+++ b/tools/dawgrun/docs/RFC.md
@@ -95,7 +95,11 @@ This section documents the implemented baseline at the time of writing.
 
 The current command set includes:
 
-- `open-pg-db` - open a named DAWGS-compatible PostgreSQL connection
+- `copy-opengraph` - copy a full graph from one named connection to another
+- `open` - open a named DAWGS-compatible connection (PostgreSQL or Neo4j)
+- `list-connections` - list currently open named backend connections
+- `save-opengraph` - export a connection's full graph as OpenGraph JSON
+- `load-opengraph` - load OpenGraph JSON into a named connection
 - `load-db-kinds` - refresh and print kind mappings for a connection
 - `lookup-kind` / `lookup-kind-id` - resolve kind names and IDs
 - `parse` - parse CySQL/Cypher into AST and dump highlighted output
@@ -121,11 +125,11 @@ Named connections and lazily loaded kind maps provide the basis for cross-comman
 
 - Kind maps are fetched from the live backend and cached in command scope.
 - Name/ID lookup helpers support debugging mismatches in query translation and execution.
-- Current backend connection command is PostgreSQL-specific.
+- Backend connection opening is driver-agnostic via connection-string scheme detection.
 
 ### 4.5 Known Constraints
 
-- Backend connection management is PostgreSQL-specific (`open-pg-db`); broader driver support is not yet implemented.
+- Kind ID lookup commands are PostgreSQL-specific because they depend on numeric kind IDs.
 - REPL input uses shell-style tokenization, which affects quoting behavior for Cypher string literals.
 - The tool is interactive-first; scriptability exists only in limited form through command composition and shell invocation patterns.
 
@@ -142,14 +146,14 @@ This proposal keeps the broad long-term goal intact while defining concrete near
 Requirements:
 
 - The tool MUST preserve straightforward connection management for at least PostgreSQL.
-- The tool SHOULD provide a path to generic `open-db` behavior for additional DAWGS drivers.
+- The tool SHOULD preserve backend-agnostic `open` behavior for additional DAWGS drivers.
 - Kind inspection SHOULD remain available as first-class commands and SHOULD support both name-to-ID and ID-to-name workflows.
 - Refresh semantics for kind mappings MUST remain explicit and predictable.
 
 Implementation direction:
 
 - Evolve command surface from backend-specific naming toward backend-agnostic patterns where practical.
-- Maintain compatibility with existing `open-pg-db` usage during migration.
+- Keep connection-opening semantics explicit and discoverable through command help.
 
 ### 5.2 Query Tooling
 
@@ -213,7 +217,7 @@ Practical indicators include:
 
 ## 8. Open Questions
 
-- What is the preferred migration path from `open-pg-db` to a generic multi-driver connection interface?
+- Should `open` support additional secure Neo4j URI schemes beyond `neo4j://` by default?
 - Which automation model is most valuable first: startup config profiles, scripted command batches, or both?
 - What level of translation-step introspection is useful by default versus too noisy for routine workflows?
 - Should roadmap features be tagged by maturity level directly in help output to clarify supported versus experimental behavior?

--- a/tools/dawgrun/pkg/commands/db.go
+++ b/tools/dawgrun/pkg/commands/db.go
@@ -1,44 +1,111 @@
 package commands
 
 import (
+	"flag"
 	"fmt"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/specterops/dawgs"
 	"github.com/specterops/dawgs/drivers"
+	"github.com/specterops/dawgs/drivers/neo4j"
 	"github.com/specterops/dawgs/drivers/pg"
 	"github.com/specterops/dawgs/graph"
 
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/stubs"
 )
 
-// TODO(seanj): Convert to generic open-db command that supports any available driver
-func openPGDBCmd() CommandDesc {
+func listConnectionsCmd() CommandDesc {
 	return CommandDesc{
-		args: []string{"<name>", "<connection string>"},
-		help: "Connects to a specified DAWGS-compatible Postgres DB to do graph introspection.",
+		args: []string{},
+		help: "Lists currently open named connections",
+		desc: "Prints all active connection names for this REPL session.",
 
 		Fn: func(ctx *CommandContext, fields []string) error {
+			if len(fields) != 0 {
+				return fmt.Errorf("invalid usage: list-connections")
+			}
+
+			connNames := ctx.scope.GetConnectionNames()
+			if len(connNames) == 0 {
+				fmt.Fprintln(ctx.output, "No open connections")
+				return nil
+			}
+
+			fmt.Fprintf(ctx.output, "Open connections (%d):\n", len(connNames))
+			for _, connName := range connNames {
+				fmt.Fprintf(ctx.output, "  %s\n", connName)
+			}
+
+			return nil
+		},
+	}
+}
+
+func openCmd() CommandDesc {
+	flagSet := flag.NewFlagSet("open", flag.ContinueOnError)
+
+	driverOverride := ""
+	flagSet.StringVar(&driverOverride, "driver", "", "Driver override: pg or neo4j (default: infer from connection string scheme)")
+
+	return CommandDesc{
+		args:  []string{"[flags]", "<name>", "<connection string>"},
+		help:  "Connects to a named DAWGS-compatible backend using a connection string.",
+		desc:  "Infers backend driver from the connection string scheme (postgres/postgresql => pg, neo4j => neo4j).",
+		flags: flagSet,
+
+		ClearFlagsFn: func() {
+			driverOverride = ""
+		},
+
+		Fn: func(ctx *CommandContext, fields []string) error {
+			driverOverride = ""
+			if err := flagSet.Parse(fields); err != nil {
+				return fmt.Errorf("could not parse flags: %w", err)
+			}
+
+			fields = flagSet.Args()
 			if len(fields) < 2 {
-				return fmt.Errorf("invalid usage: open-pg-db <name> <connection str>")
+				return fmt.Errorf("invalid usage: open [flags] <name> <connection str>")
 			}
 
 			name := fields[0]
 			connStr := fields[1]
-			connPool, err := pg.NewPool(drivers.DatabaseConfiguration{
-				Connection: connStr,
-			})
-			if err != nil {
-				return fmt.Errorf("error opening connection pool: %w", err)
+
+			driverName := ""
+			if strings.TrimSpace(driverOverride) != "" {
+				driverName = strings.ToLower(strings.TrimSpace(driverOverride))
+			} else if detectedDriverName, err := driverFromConnectionString(connStr); err != nil {
+				return err
+			} else {
+				driverName = detectedDriverName
 			}
 
-			querier, err := dawgs.Open(ctx, "pg", dawgs.Config{
+			config := dawgs.Config{
 				ConnectionString: connStr,
-				Pool:             connPool,
-			})
+			}
+
+			switch driverName {
+			case pg.DriverName:
+				connPool, err := pg.NewPool(drivers.DatabaseConfiguration{
+					Connection: connStr,
+				})
+				if err != nil {
+					return fmt.Errorf("error opening connection pool: %w", err)
+				}
+
+				config.Pool = connPool
+			case neo4j.DriverName:
+				// No additional setup required for Neo4j before dawgs.Open.
+			default:
+				return fmt.Errorf("unsupported driver %q; expected one of: %s, %s", driverName, pg.DriverName, neo4j.DriverName)
+			}
+
+			querier, err := dawgs.Open(ctx, driverName, config)
 			if err != nil {
-				return fmt.Errorf("error opening database connection '%s': %w", connStr, err)
+				return fmt.Errorf("error opening %s database connection '%s': %w", driverName, connStr, err)
 			}
 
 			if existingConn, ok := ctx.scope.connections[name]; ok {
@@ -52,11 +119,27 @@ func openPGDBCmd() CommandDesc {
 				ctx.scope.DropConnection(name)
 			}
 
-			fmt.Fprintf(ctx.output, "Opened connection '%s'\n", name)
+			fmt.Fprintf(ctx.output, "Opened %s connection '%s'\n", driverName, name)
 			ctx.scope.AddConnection(name, querier)
 
 			return nil
 		},
+	}
+}
+
+func driverFromConnectionString(connStr string) (string, error) {
+	parsedURL, err := url.Parse(connStr)
+	if err != nil {
+		return "", fmt.Errorf("could not parse connection string: %w", err)
+	}
+
+	switch strings.ToLower(parsedURL.Scheme) {
+	case "postgres", "postgresql":
+		return pg.DriverName, nil
+	case neo4j.DriverName:
+		return neo4j.DriverName, nil
+	default:
+		return "", fmt.Errorf("unknown connection string scheme %q; expected postgres/postgresql or neo4j", parsedURL.Scheme)
 	}
 }
 

--- a/tools/dawgrun/pkg/commands/db.go
+++ b/tools/dawgrun/pkg/commands/db.go
@@ -87,6 +87,7 @@ func openCmd() CommandDesc {
 				ConnectionString: connStr,
 			}
 
+			openSuccess := false
 			switch driverName {
 			case pg.DriverName:
 				connPool, err := pg.NewPool(drivers.DatabaseConfiguration{
@@ -95,6 +96,11 @@ func openCmd() CommandDesc {
 				if err != nil {
 					return fmt.Errorf("error opening connection pool: %w", err)
 				}
+				defer func() {
+					if !openSuccess {
+						connPool.Close()
+					}
+				}()
 
 				config.Pool = connPool
 			case neo4j.DriverName:
@@ -108,7 +114,7 @@ func openCmd() CommandDesc {
 				return fmt.Errorf("error opening %s database connection '%s': %w", driverName, connStr, err)
 			}
 
-			if existingConn, ok := ctx.scope.connections[name]; ok {
+			if existingConn, ok := ctx.scope.GetConnection(name); ok {
 				// Warn+close existing connection before overwriting it
 				ctx.output.Warnf("Discarding previous connection for '%s'", name)
 				if err := existingConn.Close(ctx); err != nil {
@@ -121,6 +127,7 @@ func openCmd() CommandDesc {
 
 			fmt.Fprintf(ctx.output, "Opened %s connection '%s'\n", driverName, name)
 			ctx.scope.AddConnection(name, querier)
+			openSuccess = true
 
 			return nil
 		},
@@ -168,7 +175,7 @@ func getPGDBKinds() CommandDesc {
 }
 
 func loadKindMap(ctx *CommandContext, connName string) (stubs.KindMap, error) {
-	conn, ok := ctx.scope.connections[connName]
+	conn, ok := ctx.scope.GetConnection(connName)
 	if !ok {
 		return nil, fmt.Errorf("unknown connection %s; did you `open` it?", connName)
 	}

--- a/tools/dawgrun/pkg/commands/opengraph.go
+++ b/tools/dawgrun/pkg/commands/opengraph.go
@@ -1,0 +1,177 @@
+package commands
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/specterops/dawgs/opengraph"
+)
+
+func saveOpenGraphCmd() CommandDesc {
+	flagSet := flag.NewFlagSet("save-opengraph", flag.ContinueOnError)
+
+	outFilePath := ""
+	flagSet.StringVar(&outFilePath, "out", "", "Path for writing OpenGraph JSON output (defaults to console output)")
+
+	return CommandDesc{
+		args:  []string{"[flags]", "<connection>"},
+		help:  "Dumps all data from a connection as OpenGraph JSON",
+		desc:  "Writes pretty OpenGraph JSON to the console by default, or to a file when -out is provided.",
+		flags: flagSet,
+
+		ClearFlagsFn: func() {
+			outFilePath = ""
+		},
+
+		Fn: func(ctx *CommandContext, fields []string) error {
+			outFilePath = ""
+			if err := flagSet.Parse(fields); err != nil {
+				return fmt.Errorf("could not parse flags: %w", err)
+			}
+
+			fields = flagSet.Args()
+			if len(fields) != 1 {
+				return fmt.Errorf("invalid usage: save-opengraph [flags] <connection>")
+			}
+
+			connName := fields[0]
+			conn, ok := ctx.scope.connections[connName]
+			if !ok {
+				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
+			}
+
+			exportBuffer := new(bytes.Buffer)
+			if err := opengraph.Export(ctx, conn, exportBuffer); err != nil {
+				return fmt.Errorf("could not export opengraph data: %w", err)
+			}
+
+			if strings.TrimSpace(outFilePath) == "" {
+				ctx.output.WriteHighlighted(exportBuffer.String(), "json")
+				return nil
+			}
+
+			outFile, err := os.Create(outFilePath)
+			if err != nil {
+				return fmt.Errorf("could not create output file %s: %w", outFilePath, err)
+			}
+			defer outFile.Close()
+
+			if _, err := outFile.Write(exportBuffer.Bytes()); err != nil {
+				return fmt.Errorf("could not write output file %s: %w", outFilePath, err)
+			}
+
+			doc, err := opengraph.ParseDocument(bytes.NewReader(exportBuffer.Bytes()))
+			if err != nil {
+				return fmt.Errorf("could not parse exported opengraph document: %w", err)
+			}
+
+			fmt.Fprintf(ctx.output, "Wrote %d nodes and %d edges to %s\n", len(doc.Graph.Nodes), len(doc.Graph.Edges), outFilePath)
+			return nil
+		},
+	}
+}
+
+func loadOpenGraphCmd() CommandDesc {
+	return CommandDesc{
+		args: []string{"<connection>", "<inputfilename>"},
+		help: "Loads an OpenGraph JSON file into a connection",
+		desc: "Parses and validates an OpenGraph data file, then writes all nodes and edges to the specified connection.",
+
+		Fn: func(ctx *CommandContext, fields []string) error {
+			if len(fields) != 2 {
+				return fmt.Errorf("invalid usage: load-opengraph <connection> <inputfilename>")
+			}
+
+			connName := fields[0]
+			inputFilePath := fields[1]
+
+			conn, ok := ctx.scope.connections[connName]
+			if !ok {
+				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
+			}
+
+			inputFile, err := os.Open(inputFilePath)
+			if err != nil {
+				return fmt.Errorf("could not open opengraph input file %s: %w", inputFilePath, err)
+			}
+			defer inputFile.Close()
+
+			doc, err := opengraph.ParseDocument(inputFile)
+			if err != nil {
+				return fmt.Errorf("could not parse opengraph input file %s: %w", inputFilePath, err)
+			}
+
+			if _, err := opengraph.WriteGraph(ctx, conn, &doc.Graph); err != nil {
+				return fmt.Errorf("could not write opengraph data into connection %s: %w", connName, err)
+			}
+
+			fmt.Fprintf(ctx.output, "Loaded %d nodes and %d edges from %s into connection '%s'\n", len(doc.Graph.Nodes), len(doc.Graph.Edges), inputFilePath, connName)
+			return nil
+		},
+	}
+}
+
+func copyOpenGraphCmd() CommandDesc {
+	return CommandDesc{
+		args: []string{"<from-connection>", "<to-connection>"},
+		help: "Copies all graph data from one connection to another",
+		desc: "Exports OpenGraph JSON from one active connection and writes the resulting nodes and edges into another active connection.",
+
+		Fn: func(ctx *CommandContext, fields []string) error {
+			if len(fields) != 2 {
+				return fmt.Errorf("invalid usage: copy-opengraph <from-connection> <to-connection>")
+			}
+
+			fromConnName := fields[0]
+			toConnName := fields[1]
+			if fromConnName == toConnName {
+				return fmt.Errorf("source and destination connections must differ")
+			}
+
+			fromConn, ok := ctx.scope.connections[fromConnName]
+			if !ok {
+				return fmt.Errorf("connection %s not found; did you `open` it?", fromConnName)
+			}
+
+			toConn, ok := ctx.scope.connections[toConnName]
+			if !ok {
+				return fmt.Errorf("connection %s not found; did you `open` it?", toConnName)
+			}
+
+			pipeReader, pipeWriter := io.Pipe()
+			exportErrCh := make(chan error, 1)
+
+			go func() {
+				if err := opengraph.Export(ctx, fromConn, pipeWriter); err != nil {
+					_ = pipeWriter.CloseWithError(err)
+					exportErrCh <- err
+					return
+				}
+
+				exportErrCh <- pipeWriter.Close()
+			}()
+
+			doc, err := opengraph.ParseDocument(pipeReader)
+			exportErr := <-exportErrCh
+
+			if exportErr != nil {
+				return fmt.Errorf("could not export opengraph data from connection %s: %w", fromConnName, exportErr)
+			}
+
+			if err != nil {
+				return fmt.Errorf("could not parse streamed opengraph data from connection %s: %w", fromConnName, err)
+			}
+
+			if _, err := opengraph.WriteGraph(ctx, toConn, &doc.Graph); err != nil {
+				return fmt.Errorf("could not copy opengraph data into connection %s: %w", toConnName, err)
+			}
+
+			fmt.Fprintf(ctx.output, "Copied %d nodes and %d edges from connection '%s' to connection '%s'\n", len(doc.Graph.Nodes), len(doc.Graph.Edges), fromConnName, toConnName)
+			return nil
+		},
+	}
+}

--- a/tools/dawgrun/pkg/commands/opengraph.go
+++ b/tools/dawgrun/pkg/commands/opengraph.go
@@ -39,7 +39,7 @@ func saveOpenGraphCmd() CommandDesc {
 			}
 
 			connName := fields[0]
-			conn, ok := ctx.scope.connections[connName]
+			conn, ok := ctx.scope.GetConnection(connName)
 			if !ok {
 				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
 			}
@@ -89,7 +89,7 @@ func loadOpenGraphCmd() CommandDesc {
 			connName := fields[0]
 			inputFilePath := fields[1]
 
-			conn, ok := ctx.scope.connections[connName]
+			conn, ok := ctx.scope.GetConnection(connName)
 			if !ok {
 				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
 			}
@@ -132,12 +132,12 @@ func copyOpenGraphCmd() CommandDesc {
 				return fmt.Errorf("source and destination connections must differ")
 			}
 
-			fromConn, ok := ctx.scope.connections[fromConnName]
+			fromConn, ok := ctx.scope.GetConnection(fromConnName)
 			if !ok {
 				return fmt.Errorf("connection %s not found; did you `open` it?", fromConnName)
 			}
 
-			toConn, ok := ctx.scope.connections[toConnName]
+			toConn, ok := ctx.scope.GetConnection(toConnName)
 			if !ok {
 				return fmt.Errorf("connection %s not found; did you `open` it?", toConnName)
 			}
@@ -156,6 +156,9 @@ func copyOpenGraphCmd() CommandDesc {
 			}()
 
 			doc, err := opengraph.ParseDocument(pipeReader)
+			if err != nil {
+				_ = pipeReader.CloseWithError(err)
+			}
 			exportErr := <-exportErrCh
 
 			if exportErr != nil {

--- a/tools/dawgrun/pkg/commands/registry.go
+++ b/tools/dawgrun/pkg/commands/registry.go
@@ -7,17 +7,21 @@ import (
 )
 
 var cmdRegistry map[string]CommandDesc = map[string]CommandDesc{
-	"exit":           quitCmd(),
-	"explain-psql":   explainAsPsqlCmd(),
-	"load-db-kinds":  getPGDBKinds(),
-	"lookup-kind":    lookupKindCmd(),
-	"lookup-kind-id": lookupKindIDCmd(),
-	"open-pg-db":     openPGDBCmd(),
-	"parse":          parseCmd(),
-	"query-cypher":   queryCypherCmd(),
-	"quit":           quitCmd(),
-	"runtime-trace":  runtimeTraceCmd(),
-	"translate-psql": translateToPsqlCmd(),
+	"copy-opengraph":   copyOpenGraphCmd(),
+	"exit":             quitCmd(),
+	"explain-psql":     explainAsPsqlCmd(),
+	"list-connections": listConnectionsCmd(),
+	"load-opengraph":   loadOpenGraphCmd(),
+	"load-db-kinds":    getPGDBKinds(),
+	"lookup-kind":      lookupKindCmd(),
+	"lookup-kind-id":   lookupKindIDCmd(),
+	"open":             openCmd(),
+	"parse":            parseCmd(),
+	"query-cypher":     queryCypherCmd(),
+	"quit":             quitCmd(),
+	"runtime-trace":    runtimeTraceCmd(),
+	"save-opengraph":   saveOpenGraphCmd(),
+	"translate-psql":   translateToPsqlCmd(),
 }
 
 func init() {

--- a/tools/dawgrun/pkg/commands/types.go
+++ b/tools/dawgrun/pkg/commands/types.go
@@ -170,3 +170,11 @@ func (s *Scope) DropConnection(name string) {
 	delete(s.connections, name)
 	delete(s.connKindMaps, name)
 }
+
+func (s *Scope) GetConnection(name string) (graph.Database, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	conn, ok := s.connections[name]
+	return conn, ok
+}

--- a/tools/dawgrun/pkg/commands/types.go
+++ b/tools/dawgrun/pkg/commands/types.go
@@ -5,7 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
@@ -142,6 +144,14 @@ func (s *Scope) GetNumConnections() int {
 	defer s.mu.RUnlock()
 
 	return len(s.connections)
+}
+
+// GetConnectionNames returns sorted names for tracked database connections.
+func (s *Scope) GetConnectionNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return slices.Sorted(maps.Keys(s.connections))
 }
 
 // AddConnection stores or replaces a named database connection in scope.


### PR DESCRIPTION
## Description

This is a developer tooling change only. 
Updates dawgrun to be agnostic to backend database type when opening a connection.
Updates `spew` config to no longer show memory addresses.
Removes `open-pg-db` and replaces with `open`, which will auto-detect backing driver via connection scheme (or can be manually provided w/ `-driver blah`
Adds OpenGraph tooling:
- `save-opengraph` exports the contents of a connection to a JSON file in OpenGraph format
- `load-opengraph` imports the contents of an OpenGraph JSON file into an open connection
- `copy-opengraph` copies the full contents of one connection to another using OpenGraph as an interchange format. Works between PG and Neo4j =]

## Type of Change

- [X] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [X] Build / CI / tooling
- [X] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual integration tests run (`go test -tags manual_integration ./integration/...`)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [X] Code is formatted
- [ ] All existing tests pass
- [X] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generic open command with automatic backend detection (Postgres or Neo4j) and manual driver override
  * save-opengraph, load-opengraph, and copy-opengraph for exporting/importing/copying graph data
  * list-connections to view active REPL connections

* **Documentation**
  * README and RFC updated with new commands, examples, and revised open/save/load usage

* **Improvements**
  * Cleaner REPL output and clearer command feedback
<!-- end of auto-generated comment: release notes by coderabbit.ai -->