### PR TITLE
fix(dawgrun): select or init default graph on db connect

### DIFF
--- a/tools/dawgrun/pkg/commands/db.go
+++ b/tools/dawgrun/pkg/commands/db.go
@@ -48,7 +48,12 @@ func openCmd() CommandDesc {
 	flagSet := flag.NewFlagSet("open", flag.ContinueOnError)
 
 	driverOverride := ""
+	defaultGraphName := "default"
+	initGraphOnFail := false
+
 	flagSet.StringVar(&driverOverride, "driver", "", "Driver override: pg or neo4j (default: infer from connection string scheme)")
+	flagSet.StringVar(&defaultGraphName, "default-graph", "default", "Graph that should be referenced in graph operations")
+	flagSet.BoolVar(&initGraphOnFail, "init-graph", false, "Whether the specified default graph should be created if opening it fails")
 
 	return CommandDesc{
 		args:  []string{"[flags]", "<name>", "<connection string>"},
@@ -58,6 +63,8 @@ func openCmd() CommandDesc {
 
 		ClearFlagsFn: func() {
 			driverOverride = ""
+			defaultGraphName = "default"
+			initGraphOnFail = false
 		},
 
 		Fn: func(ctx *CommandContext, fields []string) error {
@@ -112,6 +119,21 @@ func openCmd() CommandDesc {
 			querier, err := dawgs.Open(ctx, driverName, config)
 			if err != nil {
 				return fmt.Errorf("error opening %s database connection '%s': %w", driverName, connStr, err)
+			}
+
+			defaultGraph := graph.Graph{Name: defaultGraphName}
+			if err := querier.SetDefaultGraph(ctx, defaultGraph); err != nil {
+				if !initGraphOnFail {
+					return fmt.Errorf("could not set default graph: %w", err)
+				}
+
+				graphSchema := graph.Schema{
+					Graphs:       []graph.Graph{defaultGraph},
+					DefaultGraph: defaultGraph,
+				}
+				if err := querier.AssertSchema(ctx, graphSchema); err != nil {
+					return fmt.Errorf("could not initialize graph schema: %w", err)
+				}
 			}
 
 			if existingConn, ok := ctx.scope.GetConnection(name); ok {


### PR DESCRIPTION
## Description

Update dawgrun connection creation to select or create a default (or, named) graph when opening connection

Resolves: <TICKET_OR_ISSUE_NUMBER>

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [ ] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--default-graph` flag to specify the default graph name for database connections (defaults to "default")
  * Added `--init-graph` flag to enable automatic schema initialization when the default graph setup fails
  * Improved connection initialization to attempt setting the default graph and optionally initialize schema on failure

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/DAWGS/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->