### PR TITLE
feat(dawgrun): CLI mode

### DIFF
--- a/tools/dawgrun/.gitignore
+++ b/tools/dawgrun/.gitignore
@@ -1,2 +1,2 @@
 .build.env
-dawgrun
+/dawgrun

--- a/tools/dawgrun/README.md
+++ b/tools/dawgrun/README.md
@@ -283,3 +283,5 @@ configured connection the first time a command needs it.
 Syntax highlighting style defaults to `monokai`, but can be configured via
 the `DAWGRUN_STYLE` environment variable. 
 Any styles in [Chroma](https://github.com/alecthomas/chroma/tree/master/styles) are available for use as a syntax highlighting style. 
+CLI mode disables all terminal styling, including syntax highlighting
+and styled warnings, when stdout is not a terminal.

--- a/tools/dawgrun/README.md
+++ b/tools/dawgrun/README.md
@@ -28,9 +28,10 @@
 `dawgrun` is a work-in-progress developer tool for interacting with
 `DAWGS` and the data structures it produces.
 
-It currently runs as a REPL for introspecting a `DAWGS`-compatible
-graph backend (Postgres or Neo4j), parsing and translating Cypher
-queries, and executing queries against a live connection.
+It runs as a REPL or one-shot CLI for introspecting a
+`DAWGS`-compatible graph backend (Postgres or Neo4j), parsing and
+translating Cypher queries, and executing queries against a live
+connection.
 
 ## Building
 
@@ -50,9 +51,17 @@ To switch the build back to mainline:
 
 ## Running
 
-You are dropped into a prompt:
+Run without arguments to start the REPL:
 
     dawgrun >
+
+Pass a command and its arguments to execute that command once and exit:
+
+    dawgrun parse "match (n) return n limit 1"
+
+CLI mode reads `$XDG_CONFIG_HOME/dawgrun/config.json` (or the platform
+equivalent) if it exists, so commands can refer to configured
+connection names without an interactive `open` first.
 
 At any time, run `help` to list commands or `help <command>` for
 detailed usage, flag defaults, and description.
@@ -68,9 +77,10 @@ Available commands:
     exit                            Quit
     explain-psql                    Explains a translated query over an active PG connection
     help                            This help message, but also more detailed help for individual commands
-    list-connections                Lists currently open named connections
-    load-opengraph                  Loads an OpenGraph JSON file into a connection
+    list-connections                Lists open and configured named connections
+    load-connections                Loads named backend connections from dawgrun config
     load-db-kinds                   Loads/shows the kind mapping from the specified DB into the 'active set'
+    load-opengraph                  Loads an OpenGraph JSON file into a connection
     lookup-kind                     Looks up a kind from database based on kind name
     lookup-kind-id                  Looks up a kind from database based on kind ID
     open                            Connects to a named DAWGS-compatible backend using a connection string.
@@ -78,6 +88,7 @@ Available commands:
     query-cypher                    Executes a Cypher query and renders table or JSON output
     quit                            Quit
     runtime-trace                   Manage runtime tracing
+    save-connections                Saves open named backend connections to dawgrun config
     save-opengraph                  Dumps all data from a connection as OpenGraph JSON
     translate-psql                  Parses a query and converts it to the underlying PostgreSQL query
 ```
@@ -89,9 +100,25 @@ first argument. Names are assigned when you open the connection and
 are reused for the remainder of the session. The bottom-right status
 widget shows the current number of open connections.
 
-To list their names directly:
+To list open and configured connection names directly:
 
     dawgrun > list-connections
+
+Configured connections loaded in CLI mode are listed as unopened until
+a command needs to use them.
+
+Save the currently open connections to the default config file:
+
+    dawgrun > save-connections
+
+Load and open connections from the default config file:
+
+    dawgrun > load-connections
+
+Both commands accept an optional config path:
+
+    dawgrun > save-connections ./dawgrun.local.json
+    dawgrun > load-connections ./dawgrun.local.json
 
 A "kind map" is the mapping between a graph's kind names (e.g.
 `User`, `Group`) and the numeric IDs they are stored under in
@@ -222,6 +249,34 @@ The REPL persists command history to
 `$XDG_CONFIG_HOME/dawgrun/history.txt` (or the platform equivalent),
 capped at 1000 lines, so recent commands are available via the
 arrow keys across sessions.
+
+## Configuration
+
+The default config file is `$XDG_CONFIG_HOME/dawgrun/config.json` (or
+the platform equivalent). It currently stores named connection entries:
+
+```json
+{
+  "connections": {
+    "local": {
+      "driver": "pg",
+      "connection_string": "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable"
+    },
+    "neo": {
+      "driver": "neo4j",
+      "connection_string": "neo4j://neo4j:password@localhost:7687"
+    }
+  }
+}
+```
+
+The `driver` field is optional when the connection string scheme can be
+autodetected, but it is required for connection strings without a
+scheme.
+
+REPL mode loads these connections only when `load-connections` is run.
+CLI mode reads the default config at startup and lazily opens a
+configured connection the first time a command needs it.
 
 ## Styling
 

--- a/tools/dawgrun/README.md
+++ b/tools/dawgrun/README.md
@@ -111,6 +111,9 @@ Save the currently open connections to the default config file:
 
     dawgrun > save-connections
 
+If no connections are open, `save-connections` refuses to overwrite an
+existing config that already contains saved connections.
+
 Load and open connections from the default config file:
 
     dawgrun > load-connections

--- a/tools/dawgrun/cmd/dawgrun/main.go
+++ b/tools/dawgrun/cmd/dawgrun/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/trace"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -52,7 +53,7 @@ func main() {
 }
 
 func cliMain(appConfigBaseDir string, args []string) int {
-	scope := commands.NewScope()
+	scope := commands.NewScope(commands.RunModeCLI)
 	defer func() {
 		if err := scope.CloseConnections(context.Background()); err != nil {
 			slog.Error("could not close cli connections", slog.String("error", err.Error()))
@@ -88,7 +89,7 @@ func replMain(appConfigBaseDir string) {
 
 	handler := new(handler)
 	handler.appConfigBaseDir = appConfigBaseDir
-	handler.cmdScope = commands.NewScope()
+	handler.cmdScope = commands.NewScope(commands.RunModeREPL)
 	handler.r = repl.NewRepl(handler, &repl.Options{
 		HistoryFilePath: filepath.Join(appConfigBaseDir, "history.txt"),
 		HistoryMaxLines: 1000,
@@ -241,7 +242,9 @@ func runCommandWithOptions(ctx context.Context, instance *repl.Repl, scope *comm
 
 	command := strings.ToLower(fields[0])
 	rest := fields[1:]
-	if cmd, ok := commands.Registry()[command]; ok {
+
+	cmd, ok := commands.Registry()[command]
+	if ok && !slices.Contains(cmd.DisallowRunModes, scope.GetRunMode()) {
 		cmdCtx := commands.NewCommandContext(ctx, instance, scope, appConfigBaseDir)
 		cmdCtx.SetStyledOutputEnabled(options.styledOutputEnabled)
 		defer trace.StartRegion(cmdCtx, fmt.Sprintf("command-%s", command)).End()

--- a/tools/dawgrun/cmd/dawgrun/main.go
+++ b/tools/dawgrun/cmd/dawgrun/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime/trace"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 	repl "github.com/specterops/go-repl"
 
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/commands"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
 )
 
 var (
@@ -34,6 +36,46 @@ func main() {
 	// Configure spew's display options
 	spew.Config.DisablePointerAddresses = true
 
+	appConfigBaseDir, err := ensureAppConfigBaseDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		os.Exit(1)
+	}
+
+	// CLI mode if args, otherwise interactive
+	if len(os.Args) > 1 {
+		os.Exit(cliMain(appConfigBaseDir, os.Args[1:]))
+	} else {
+		replMain(appConfigBaseDir)
+	}
+}
+
+func cliMain(appConfigBaseDir string, args []string) int {
+	scope := commands.NewScope()
+	defer func() {
+		if err := scope.CloseConnections(context.Background()); err != nil {
+			slog.Error("could not close cli connections", slog.String("error", err.Error()))
+		}
+	}()
+
+	if err := loadDefaultConfigConnectionStrings(scope, appConfigBaseDir); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		return 1
+	}
+
+	output, err := runCommand(context.Background(), nil, scope, appConfigBaseDir, args)
+	if output != "" {
+		fmt.Print(output)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		return 1
+	}
+
+	return 0
+}
+
+func replMain(appConfigBaseDir string) {
 	fmt.Printf("\n%s\n%s",
 		art,
 		bannerStyle.Render(banner),
@@ -41,21 +83,11 @@ func main() {
 	fmt.Printf("\n\n\n")
 	fmt.Printf(" ::: DAWGRUN REPL ::: Type 'help' for more info\n")
 
-	userConfigDir, err := os.UserConfigDir()
-	if err != nil {
-		panic(fmt.Errorf("could not get user config dir: %w", err))
-	}
-
-	// TODO: Someday, also load a config file from here for highlighting color scheme, colors enablement, etc
-	appConfigBaseDir := path.Join(userConfigDir, "dawgrun")
-	if err := os.MkdirAll(appConfigBaseDir, 0o750); err != nil {
-		panic(fmt.Errorf("could not create dawgrun config dir: %w", err))
-	}
-
 	handler := new(handler)
+	handler.appConfigBaseDir = appConfigBaseDir
 	handler.cmdScope = commands.NewScope()
 	handler.r = repl.NewRepl(handler, &repl.Options{
-		HistoryFilePath: path.Join(appConfigBaseDir, "history.txt"),
+		HistoryFilePath: filepath.Join(appConfigBaseDir, "history.txt"),
 		HistoryMaxLines: 1000,
 		StatusWidgets: &repl.StatusWidgetFns{
 			Right: makeConnectionsStatusWidget(handler.cmdScope),
@@ -67,14 +99,44 @@ func main() {
 	}
 }
 
+func ensureAppConfigBaseDir() (string, error) {
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("could not get user config dir: %w", err)
+	}
+
+	appConfigBaseDir := filepath.Join(userConfigDir, "dawgrun")
+	if err := os.MkdirAll(appConfigBaseDir, 0o750); err != nil {
+		return "", fmt.Errorf("could not create dawgrun config dir: %w", err)
+	}
+
+	return appConfigBaseDir, nil
+}
+
+func loadDefaultConfigConnectionStrings(scope *commands.Scope, appConfigBaseDir string) error {
+	configPath := types.DefaultConfigPath(appConfigBaseDir)
+	config, err := types.LoadConfig(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return err
+	}
+
+	scope.SetConnectionConfigs(config.Connections)
+	return nil
+}
+
 var (
 	_ repl.Handler   = (*handler)(nil)
 	_ repl.Completer = (*handler)(nil)
 )
 
 type handler struct {
-	r        *repl.Repl
-	cmdScope *commands.Scope
+	r                *repl.Repl
+	cmdScope         *commands.Scope
+	appConfigBaseDir string
 }
 
 func (h *handler) Prompt() string {
@@ -151,10 +213,23 @@ func (h *handler) Eval(line string) string {
 		return "Woof!"
 	}
 
+	output, err := runCommand(ctx, h.r, h.cmdScope, h.appConfigBaseDir, fields)
+	if err != nil {
+		return err.Error()
+	}
+
+	return output
+}
+
+func runCommand(ctx context.Context, instance *repl.Repl, scope *commands.Scope, appConfigBaseDir string, fields []string) (string, error) {
+	if len(fields) == 0 {
+		return "", fmt.Errorf("no command provided")
+	}
+
 	command := strings.ToLower(fields[0])
 	rest := fields[1:]
 	if cmd, ok := commands.Registry()[command]; ok {
-		cmdCtx := commands.NewCommandContext(ctx, h.r, h.cmdScope)
+		cmdCtx := commands.NewCommandContext(ctx, instance, scope, appConfigBaseDir)
 		defer trace.StartRegion(cmdCtx, fmt.Sprintf("command-%s", command)).End()
 		err := cmd.Fn(cmdCtx, rest)
 		// Reset command's associated flags after exec
@@ -164,18 +239,18 @@ func (h *handler) Eval(line string) string {
 			}
 		}()
 		if err != nil {
-			return fmt.Sprintf("%s failed: %v", command, err)
+			return "", fmt.Errorf("%s failed: %w", command, err)
 		}
 
 		out := cmdCtx.OutputString()
-		if !strings.HasSuffix(out, "\n") {
-			return out + "\n"
-		} else {
-			return out
+		if out != "" && !strings.HasSuffix(out, "\n") {
+			return out + "\n", nil
 		}
+
+		return out, nil
 	}
 
-	return fmt.Sprintf("Unknown command %s; try `help`?", command)
+	return "", fmt.Errorf("unknown command %s; try `help`?", command)
 }
 
 func makeConnectionsStatusWidget(cmdScope *commands.Scope) repl.StatusWidgetFn {

--- a/tools/dawgrun/cmd/dawgrun/main.go
+++ b/tools/dawgrun/cmd/dawgrun/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/commands"
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
+	"golang.org/x/term"
 )
 
 var (
@@ -63,7 +64,9 @@ func cliMain(appConfigBaseDir string, args []string) int {
 		return 1
 	}
 
-	output, err := runCommand(context.Background(), nil, scope, appConfigBaseDir, args)
+	output, err := runCommandWithOptions(context.Background(), nil, scope, appConfigBaseDir, args, runCommandOptions{
+		styledOutputEnabled: term.IsTerminal(int(os.Stdout.Fd())),
+	})
 	if output != "" {
 		fmt.Print(output)
 	}
@@ -222,6 +225,16 @@ func (h *handler) Eval(line string) string {
 }
 
 func runCommand(ctx context.Context, instance *repl.Repl, scope *commands.Scope, appConfigBaseDir string, fields []string) (string, error) {
+	return runCommandWithOptions(ctx, instance, scope, appConfigBaseDir, fields, runCommandOptions{
+		styledOutputEnabled: true,
+	})
+}
+
+type runCommandOptions struct {
+	styledOutputEnabled bool
+}
+
+func runCommandWithOptions(ctx context.Context, instance *repl.Repl, scope *commands.Scope, appConfigBaseDir string, fields []string, options runCommandOptions) (string, error) {
 	if len(fields) == 0 {
 		return "", fmt.Errorf("no command provided")
 	}
@@ -230,6 +243,7 @@ func runCommand(ctx context.Context, instance *repl.Repl, scope *commands.Scope,
 	rest := fields[1:]
 	if cmd, ok := commands.Registry()[command]; ok {
 		cmdCtx := commands.NewCommandContext(ctx, instance, scope, appConfigBaseDir)
+		cmdCtx.SetStyledOutputEnabled(options.styledOutputEnabled)
 		defer trace.StartRegion(cmdCtx, fmt.Sprintf("command-%s", command)).End()
 		err := cmd.Fn(cmdCtx, rest)
 		// Reset command's associated flags after exec

--- a/tools/dawgrun/cmd/dawgrun/main_test.go
+++ b/tools/dawgrun/cmd/dawgrun/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/commands"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,16 +17,26 @@ func TestRunCommandExecutesCommand(t *testing.T) {
 	require.Contains(t, output, "HELP: save-connections")
 }
 
+func TestRunCommandWithOptionsDisablesStyledOutput(t *testing.T) {
+	output, err := runCommandWithOptions(context.Background(), nil, commands.NewScope(), t.TempDir(), []string{"parse", "return", "1"}, runCommandOptions{
+		styledOutputEnabled: false,
+	})
+
+	require.NoError(t, err)
+	require.NotContains(t, output, "\x1b[")
+	require.Contains(t, output, "RegularQuery")
+}
+
 func TestLoadDefaultConfigConnectionStrings(t *testing.T) {
 	appConfigBaseDir := t.TempDir()
-	require.NoError(t, commands.SaveConfig(filepath.Join(appConfigBaseDir, "config.json"), commands.Config{
-		Connections: map[string]commands.ConnectionConfig{
+	require.NoError(t, (types.Config{
+		Connections: map[string]types.ConnectionConfig{
 			"local": {
 				Driver:           "pg",
 				ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 			},
 		},
-	}))
+	}).Save(filepath.Join(appConfigBaseDir, "config.json")))
 
 	scope := commands.NewScope()
 	require.NoError(t, loadDefaultConfigConnectionStrings(scope, appConfigBaseDir))

--- a/tools/dawgrun/cmd/dawgrun/main_test.go
+++ b/tools/dawgrun/cmd/dawgrun/main_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func TestRunCommandExecutesCommand(t *testing.T) {
-	output, err := runCommand(context.Background(), nil, commands.NewScope(), t.TempDir(), []string{"help", "save-connections"})
+	output, err := runCommand(context.Background(), nil, commands.NewScope(commands.RunModeREPL), t.TempDir(), []string{"help", "save-connections"})
 
 	require.NoError(t, err)
 	require.Contains(t, output, "HELP: save-connections")
 }
 
 func TestRunCommandWithOptionsDisablesStyledOutput(t *testing.T) {
-	output, err := runCommandWithOptions(context.Background(), nil, commands.NewScope(), t.TempDir(), []string{"parse", "return", "1"}, runCommandOptions{
+	output, err := runCommandWithOptions(context.Background(), nil, commands.NewScope(commands.RunModeCLI), t.TempDir(), []string{"parse", "return", "1"}, runCommandOptions{
 		styledOutputEnabled: false,
 	})
 
@@ -38,7 +38,7 @@ func TestLoadDefaultConfigConnectionStrings(t *testing.T) {
 		},
 	}).Save(filepath.Join(appConfigBaseDir, "config.json")))
 
-	scope := commands.NewScope()
+	scope := commands.NewScope(commands.RunModeCLI)
 	require.NoError(t, loadDefaultConfigConnectionStrings(scope, appConfigBaseDir))
 
 	connStr, ok := scope.GetConnectionString("local")
@@ -51,7 +51,7 @@ func TestLoadDefaultConfigConnectionStrings(t *testing.T) {
 }
 
 func TestLoadDefaultConfigConnectionStringsIgnoresMissingConfig(t *testing.T) {
-	scope := commands.NewScope()
+	scope := commands.NewScope(commands.RunModeCLI)
 
 	require.NoError(t, loadDefaultConfigConnectionStrings(scope, t.TempDir()))
 	require.Zero(t, scope.GetNumConnections())

--- a/tools/dawgrun/cmd/dawgrun/main_test.go
+++ b/tools/dawgrun/cmd/dawgrun/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/commands"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunCommandExecutesCommand(t *testing.T) {
+	output, err := runCommand(context.Background(), nil, commands.NewScope(), t.TempDir(), []string{"help", "save-connections"})
+
+	require.NoError(t, err)
+	require.Contains(t, output, "HELP: save-connections")
+}
+
+func TestLoadDefaultConfigConnectionStrings(t *testing.T) {
+	appConfigBaseDir := t.TempDir()
+	require.NoError(t, commands.SaveConfig(filepath.Join(appConfigBaseDir, "config.json"), commands.Config{
+		Connections: map[string]commands.ConnectionConfig{
+			"local": {
+				Driver:           "pg",
+				ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+			},
+		},
+	}))
+
+	scope := commands.NewScope()
+	require.NoError(t, loadDefaultConfigConnectionStrings(scope, appConfigBaseDir))
+
+	connStr, ok := scope.GetConnectionString("local")
+	require.True(t, ok)
+	require.Equal(t, "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable", connStr)
+	connConfig, ok := scope.GetConnectionConfig("local")
+	require.True(t, ok)
+	require.Equal(t, "pg", connConfig.Driver)
+	require.Zero(t, scope.GetNumConnections())
+}
+
+func TestLoadDefaultConfigConnectionStringsIgnoresMissingConfig(t *testing.T) {
+	scope := commands.NewScope()
+
+	require.NoError(t, loadDefaultConfigConnectionStrings(scope, t.TempDir()))
+	require.Zero(t, scope.GetNumConnections())
+}

--- a/tools/dawgrun/docs/RFC.md
+++ b/tools/dawgrun/docs/RFC.md
@@ -84,12 +84,14 @@ This section documents the implemented baseline at the time of writing.
 
 ### 4.1 Runtime Model
 
-`dawgrun` currently runs as an interactive REPL with command parsing, persistent session history, and command-name completion.
+`dawgrun` currently runs as an interactive REPL or as a one-shot CLI command executor.
 
 - Prompt: `dawgrun >`
 - History file: `$XDG_CONFIG_HOME/dawgrun/history.txt` (or platform equivalent)
+- Config file: `$XDG_CONFIG_HOME/dawgrun/config.json` (or platform equivalent)
 - Status widget: active connection count
 - Completion: command-name matching with candidate popover
+- CLI mode: `dawgrun <command> [args...]`
 
 ### 4.2 Implemented Command Surface
 
@@ -97,7 +99,9 @@ The current command set includes:
 
 - `copy-opengraph` - copy a full graph from one named connection to another
 - `open` - open a named DAWGS-compatible connection (PostgreSQL or Neo4j)
-- `list-connections` - list currently open named backend connections
+- `list-connections` - list open and configured named backend connections
+- `load-connections` - load and open named backend connections from config
+- `save-connections` - save currently open named backend connections to config
 - `save-opengraph` - export a connection's full graph as OpenGraph JSON
 - `load-opengraph` - load OpenGraph JSON into a named connection
 - `load-db-kinds` - refresh and print kind mappings for a connection
@@ -131,7 +135,7 @@ Named connections and lazily loaded kind maps provide the basis for cross-comman
 
 - Kind ID lookup commands are PostgreSQL-specific because they depend on numeric kind IDs.
 - REPL input uses shell-style tokenization, which affects quoting behavior for Cypher string literals.
-- The tool is interactive-first; scriptability exists only in limited form through command composition and shell invocation patterns.
+- CLI mode executes a single command per process; richer command batching remains future work.
 
 ## 5. Details of the Proposal
 

--- a/tools/dawgrun/pkg/commands/commandcontext.go
+++ b/tools/dawgrun/pkg/commands/commandcontext.go
@@ -38,11 +38,16 @@ type (
 		Fn CommandFn
 		// ClearFlagsFn is used to clear a command's flags after execution
 		ClearFlagsFn func()
-		args         []string
-		flags        *flag.FlagSet
-		desc         string
-		help         string
-		state        map[string]any
+		// DisallowRunModes specifies which run modes a command must not be allowed in
+		DisallowRunModes []RunMode
+		// args is a textual representation of the positional args a command accepts
+		args []string
+		// flags is the stdlib FlagSet the command parses flags with
+		flags *flag.FlagSet
+		// desc is a brief description of what the command does
+		desc string
+		// help is a long description of what the command does
+		help string
 	}
 	// CommandOutput accumulates output text and warnings for a command.
 	CommandOutput struct {

--- a/tools/dawgrun/pkg/commands/commandcontext.go
+++ b/tools/dawgrun/pkg/commands/commandcontext.go
@@ -5,17 +5,14 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"maps"
 	"os"
-	"slices"
 	"strings"
-	"sync"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/texttools"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
 	"github.com/specterops/go-repl"
-
-	"github.com/specterops/dawgs/tools/dawgrun/pkg/stubs"
 )
 
 type (
@@ -29,6 +26,8 @@ type (
 		instance *repl.Repl
 		// output is a convenience type to make issuing warnings and formatting outputs easier
 		output *CommandOutput
+		// appConfigBaseDir is the root directory for dawgrun user configuration.
+		appConfigBaseDir string
 
 		// scope is a singleton instance held by the command manager that holds any persistent state for a command.
 		scope *Scope
@@ -50,22 +49,21 @@ type (
 		warnings      []string
 		outputBuilder strings.Builder
 	}
-	// Scope holds persistent command state that can be shared across invocations.
-	Scope struct {
-		mu           sync.RWMutex
-		connections  map[string]graph.Database
-		connKindMaps map[string]stubs.KindMap
-	}
 )
 
 // NewCommandContext creates a command context with a fresh output buffer.
-func NewCommandContext(ctx context.Context, instance *repl.Repl, scope *Scope) *CommandContext {
+func NewCommandContext(ctx context.Context, instance *repl.Repl, scope *Scope, appConfigBaseDir string) *CommandContext {
 	return &CommandContext{
-		Context:  ctx,
-		output:   new(CommandOutput),
-		instance: instance,
-		scope:    scope,
+		Context:          ctx,
+		output:           new(CommandOutput),
+		instance:         instance,
+		appConfigBaseDir: appConfigBaseDir,
+		scope:            scope,
 	}
+}
+
+func (cc *CommandContext) defaultConfigPath() string {
+	return types.DefaultConfigPath(cc.appConfigBaseDir)
 }
 
 func (cc *CommandContext) warningStyle(text string) string {
@@ -106,7 +104,7 @@ func (co *CommandOutput) Write(p []byte) (n int, err error) {
 
 // WriteIndented writes text after applying tab-based indentation per line.
 func (co *CommandOutput) WriteIndented(text string, indentCount int) {
-	co.outputBuilder.WriteString(indentLines(text, indentCount))
+	co.outputBuilder.WriteString(texttools.IndentLines(text, indentCount))
 }
 
 // WriteHighlighted writes syntax-highlighted text using the configured style.
@@ -121,7 +119,7 @@ func (co *CommandOutput) WriteHighlighted(text, lexer string) {
 
 // WriteHighlightedWithStyle writes syntax-highlighted text with an explicit style.
 func (co *CommandOutput) WriteHighlightedWithStyle(text, lexer, style string) {
-	highlighted, err := highlightText(text, lexer, style)
+	highlighted, err := texttools.HighlightText(text, lexer, style)
 	if err != nil {
 		co.Warnf("Could not highlight source text: %#v", err)
 		co.outputBuilder.WriteString(text)
@@ -130,51 +128,57 @@ func (co *CommandOutput) WriteHighlightedWithStyle(text, lexer, style string) {
 	}
 }
 
-// NewScope creates an empty shared scope for command state.
-func NewScope() *Scope {
-	return &Scope{
-		connections:  make(map[string]graph.Database),
-		connKindMaps: make(map[string]stubs.KindMap),
+// EnsureConnection checks for a currently open connection or fully opens a lazy-loaded connection for a command to operate on
+func (cc *CommandContext) EnsureConnection(connName string) (graph.Database, error) {
+	if conn, ok := cc.scope.GetConnection(connName); ok {
+		return conn, nil
 	}
+
+	connConfig, ok := cc.scope.GetConnectionConfig(connName)
+	if !ok {
+		return nil, fmt.Errorf("connection %s not found; did you `open` it?", connName)
+	}
+
+	if _, err := cc.OpenConnection(connName, connConfig.ConnectionString, openConnectionOptions{
+		driverName:       connConfig.Driver,
+		defaultGraphName: "default",
+		quiet:            true,
+	}); err != nil {
+		return nil, fmt.Errorf("could not open configured connection %s: %w", connName, err)
+	}
+
+	conn, ok := cc.scope.GetConnection(connName)
+	if !ok {
+		return nil, fmt.Errorf("configured connection %s did not open", connName)
+	}
+
+	return conn, nil
 }
 
-// GetNumConnections returns the number of tracked database connections.
-func (s *Scope) GetNumConnections() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// OpenConnection fully opens a database connection on behalf of a command
+func (cc *CommandContext) OpenConnection(name string, connStr string, options openConnectionOptions) (string, error) {
+	querier, driverName, err := cc.scope.openDatabase(cc, connStr, options)
+	if err != nil {
+		return "", err
+	}
 
-	return len(s.connections)
-}
+	if existingConn, ok := cc.scope.GetConnection(name); ok {
+		cc.output.Warnf("Discarding previous connection for '%s'", name)
+		if err := existingConn.Close(cc); err != nil {
+			_ = querier.Close(cc)
+			return "", fmt.Errorf("could not close previous connection '%s' for overwriting: %w", name, err)
+		}
 
-// GetConnectionNames returns sorted names for tracked database connections.
-func (s *Scope) GetConnectionNames() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+		cc.scope.DropConnection(name)
+	}
 
-	return slices.Sorted(maps.Keys(s.connections))
-}
+	cc.scope.AddConnection(name, querier, types.ConnectionConfig{
+		Driver:           driverName,
+		ConnectionString: connStr,
+	})
+	if !options.quiet {
+		fmt.Fprintf(cc.output, "Opened %s connection '%s'\n", driverName, name)
+	}
 
-// AddConnection stores or replaces a named database connection in scope.
-func (s *Scope) AddConnection(name string, querier graph.Database) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.connections[name] = querier
-}
-
-// DropConnection removes a named connection and any cached kind map.
-func (s *Scope) DropConnection(name string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	delete(s.connections, name)
-	delete(s.connKindMaps, name)
-}
-
-func (s *Scope) GetConnection(name string) (graph.Database, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	conn, ok := s.connections[name]
-	return conn, ok
+	return driverName, nil
 }

--- a/tools/dawgrun/pkg/commands/commandcontext.go
+++ b/tools/dawgrun/pkg/commands/commandcontext.go
@@ -46,8 +46,9 @@ type (
 	}
 	// CommandOutput accumulates output text and warnings for a command.
 	CommandOutput struct {
-		warnings      []string
-		outputBuilder strings.Builder
+		warnings            []string
+		outputBuilder       strings.Builder
+		styledOutputEnabled bool
 	}
 )
 
@@ -55,11 +56,21 @@ type (
 func NewCommandContext(ctx context.Context, instance *repl.Repl, scope *Scope, appConfigBaseDir string) *CommandContext {
 	return &CommandContext{
 		Context:          ctx,
-		output:           new(CommandOutput),
+		output:           NewCommandOutput(true),
 		instance:         instance,
 		appConfigBaseDir: appConfigBaseDir,
 		scope:            scope,
 	}
+}
+
+func NewCommandOutput(styledOutputEnabled bool) *CommandOutput {
+	return &CommandOutput{
+		styledOutputEnabled: styledOutputEnabled,
+	}
+}
+
+func (cc *CommandContext) SetStyledOutputEnabled(enabled bool) {
+	cc.output.styledOutputEnabled = enabled
 }
 
 func (cc *CommandContext) defaultConfigPath() string {
@@ -67,6 +78,10 @@ func (cc *CommandContext) defaultConfigPath() string {
 }
 
 func (cc *CommandContext) warningStyle(text string) string {
+	if !cc.output.styledOutputEnabled {
+		return text
+	}
+
 	return lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("202")).
@@ -119,6 +134,11 @@ func (co *CommandOutput) WriteHighlighted(text, lexer string) {
 
 // WriteHighlightedWithStyle writes syntax-highlighted text with an explicit style.
 func (co *CommandOutput) WriteHighlightedWithStyle(text, lexer, style string) {
+	if !co.styledOutputEnabled {
+		co.outputBuilder.WriteString(text)
+		return
+	}
+
 	highlighted, err := texttools.HighlightText(text, lexer, style)
 	if err != nil {
 		co.Warnf("Could not highlight source text: %#v", err)

--- a/tools/dawgrun/pkg/commands/commandcontext_test.go
+++ b/tools/dawgrun/pkg/commands/commandcontext_test.go
@@ -18,7 +18,7 @@ func TestCommandOutputWriteHighlightedHonorsStyledOutput(t *testing.T) {
 }
 
 func TestCommandContextWarningStyleHonorsStyledOutput(t *testing.T) {
-	ctx := NewCommandContext(context.Background(), nil, NewScope(), t.TempDir())
+	ctx := NewCommandContext(context.Background(), nil, NewScope(RunModeREPL), t.TempDir())
 	ctx.SetStyledOutputEnabled(false)
 	ctx.output.Warn("watch out")
 	require.Equal(t, " * watch out\n\n", ctx.OutputString())

--- a/tools/dawgrun/pkg/commands/commandcontext_test.go
+++ b/tools/dawgrun/pkg/commands/commandcontext_test.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandOutputWriteHighlightedHonorsStyledOutput(t *testing.T) {
+	styledOutput := NewCommandOutput(true)
+	styledOutput.WriteHighlightedWithStyle(`{"key":"value"}`, "json", "monokai")
+	require.Contains(t, styledOutput.outputBuilder.String(), "\x1b[")
+
+	plainOutput := NewCommandOutput(false)
+	plainOutput.WriteHighlightedWithStyle(`{"key":"value"}`, "json", "monokai")
+	require.Equal(t, `{"key":"value"}`, plainOutput.outputBuilder.String())
+}
+
+func TestCommandContextWarningStyleHonorsStyledOutput(t *testing.T) {
+	ctx := NewCommandContext(context.Background(), nil, NewScope(), t.TempDir())
+	ctx.SetStyledOutputEnabled(false)
+	ctx.output.Warn("watch out")
+	require.Equal(t, " * watch out\n\n", ctx.OutputString())
+}

--- a/tools/dawgrun/pkg/commands/commandscope.go
+++ b/tools/dawgrun/pkg/commands/commandscope.go
@@ -13,6 +13,13 @@ import (
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
 )
 
+type RunMode int
+
+const (
+	RunModeREPL RunMode = iota
+	RunModeCLI
+)
+
 type (
 	// Scope holds persistent command state that can be shared across invocations.
 	Scope struct {
@@ -21,6 +28,7 @@ type (
 		connectionConfigs map[string]types.ConnectionConfig
 		connKindMaps      map[string]stubs.KindMap
 		openDatabase      databaseOpener
+		runMode           RunMode
 	}
 
 	databaseOpener        func(context.Context, string, openConnectionOptions) (graph.Database, string, error)
@@ -33,12 +41,13 @@ type (
 )
 
 // NewScope creates an empty shared scope for command state.
-func NewScope() *Scope {
+func NewScope(runMode RunMode) *Scope {
 	return &Scope{
 		connections:       make(map[string]graph.Database),
 		connectionConfigs: make(map[string]types.ConnectionConfig),
 		connKindMaps:      make(map[string]stubs.KindMap),
 		openDatabase:      openDAWGSDatabase,
+		runMode:           runMode,
 	}
 }
 
@@ -174,4 +183,8 @@ func (s *Scope) CloseConnections(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *Scope) GetRunMode() RunMode {
+	return s.runMode
 }

--- a/tools/dawgrun/pkg/commands/commandscope.go
+++ b/tools/dawgrun/pkg/commands/commandscope.go
@@ -1,0 +1,177 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/stubs"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
+)
+
+type (
+	// Scope holds persistent command state that can be shared across invocations.
+	Scope struct {
+		mu                sync.RWMutex
+		connections       map[string]graph.Database
+		connectionConfigs map[string]types.ConnectionConfig
+		connKindMaps      map[string]stubs.KindMap
+		openDatabase      databaseOpener
+	}
+
+	databaseOpener        func(context.Context, string, openConnectionOptions) (graph.Database, string, error)
+	openConnectionOptions struct {
+		driverName       string
+		defaultGraphName string
+		initGraphOnFail  bool
+		quiet            bool
+	}
+)
+
+// NewScope creates an empty shared scope for command state.
+func NewScope() *Scope {
+	return &Scope{
+		connections:       make(map[string]graph.Database),
+		connectionConfigs: make(map[string]types.ConnectionConfig),
+		connKindMaps:      make(map[string]stubs.KindMap),
+		openDatabase:      openDAWGSDatabase,
+	}
+}
+
+// GetNumConnections returns the number of tracked database connections.
+func (s *Scope) GetNumConnections() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.connections)
+}
+
+// GetConnectionNames returns sorted names for tracked database connections.
+func (s *Scope) GetConnectionNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return slices.Sorted(maps.Keys(s.connections))
+}
+
+// GetUnopenedConnectionNames returns sorted names for configured connections that do not have open handles yet.
+func (s *Scope) GetUnopenedConnectionNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	unopenedConnections := make(map[string]struct{})
+	for connName := range s.connectionConfigs {
+		if _, isOpen := s.connections[connName]; !isOpen {
+			unopenedConnections[connName] = struct{}{}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(unopenedConnections))
+}
+
+// AddConnection stores or replaces a named database connection in scope.
+func (s *Scope) AddConnection(name string, querier graph.Database, config types.ConnectionConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.connections[name] = querier
+	s.connectionConfigs[name] = config
+}
+
+// DropConnection removes a named connection and any cached kind map.
+func (s *Scope) DropConnection(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.connections, name)
+	delete(s.connectionConfigs, name)
+	delete(s.connKindMaps, name)
+}
+
+func (s *Scope) GetConnection(name string) (graph.Database, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	conn, ok := s.connections[name]
+	return conn, ok
+}
+
+func (s *Scope) GetConnectionString(name string) (string, bool) {
+	config, ok := s.GetConnectionConfig(name)
+	return config.ConnectionString, ok
+}
+
+func (s *Scope) GetConnectionConfig(name string) (types.ConnectionConfig, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	config, ok := s.connectionConfigs[name]
+	return config, ok
+}
+
+func (s *Scope) SetConnectionStrings(connectionStrings map[string]string) {
+	connectionConfigs := make(map[string]types.ConnectionConfig, len(connectionStrings))
+	for name, connStr := range connectionStrings {
+		connectionConfigs[name] = types.ConnectionConfig{ConnectionString: connStr}
+	}
+
+	s.SetConnectionConfigs(connectionConfigs)
+}
+
+func (s *Scope) SetConnectionConfigs(connectionConfigs map[string]types.ConnectionConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for name, config := range connectionConfigs {
+		s.connectionConfigs[name] = config
+	}
+}
+
+func (s *Scope) GetOpenConnectionStrings() map[string]string {
+	connectionConfigs := s.GetOpenConnectionConfigs()
+	connectionStrings := make(map[string]string, len(connectionConfigs))
+	for name, config := range connectionConfigs {
+		connectionStrings[name] = config.ConnectionString
+	}
+
+	return connectionStrings
+}
+
+func (s *Scope) GetOpenConnectionConfigs() map[string]types.ConnectionConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	connectionConfigs := make(map[string]types.ConnectionConfig, len(s.connections))
+	for name := range s.connections {
+		if config, ok := s.connectionConfigs[name]; ok {
+			connectionConfigs[name] = config
+		}
+	}
+
+	return connectionConfigs
+}
+
+func (s *Scope) CloseConnections(ctx context.Context) error {
+	s.mu.Lock()
+	connections := s.connections
+	s.connections = make(map[string]graph.Database)
+	s.connKindMaps = make(map[string]stubs.KindMap)
+	s.mu.Unlock()
+
+	var closeErrs []string
+	for _, connName := range slices.Sorted(maps.Keys(connections)) {
+		if err := connections[connName].Close(ctx); err != nil {
+			closeErrs = append(closeErrs, fmt.Sprintf("%s: %s", connName, err.Error()))
+		}
+	}
+
+	if len(closeErrs) > 0 {
+		return fmt.Errorf("could not close connection(s): %s", strings.Join(closeErrs, "; "))
+	}
+
+	return nil
+}

--- a/tools/dawgrun/pkg/commands/config.go
+++ b/tools/dawgrun/pkg/commands/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"path/filepath"
 	"slices"
 
@@ -14,9 +15,10 @@ const configFileName = "config.json"
 
 func loadConnectionsCmd() CommandDesc {
 	return CommandDesc{
-		args: []string{"[config-file]"},
-		help: "Loads named backend connections from dawgrun config",
-		desc: "Reads the connections object from config.json, then opens each named connection in the current session.",
+		args:             []string{"[config-file]"},
+		help:             "Loads named backend connections from dawgrun config",
+		desc:             "Reads the connections object from config.json, then opens each named connection in the current session.",
+		DisallowRunModes: []RunMode{RunModeCLI},
 
 		Fn: func(ctx *CommandContext, fields []string) error {
 			configPath, err := resolveConfigPath(ctx, fields, "load-connections [config-file]")
@@ -60,9 +62,10 @@ func loadConnectionsCmd() CommandDesc {
 
 func saveConnectionsCmd() CommandDesc {
 	return CommandDesc{
-		args: []string{"[config-file]"},
-		help: "Saves open named backend connections to dawgrun config",
-		desc: "Writes the currently open connection names and connection strings to config.json.",
+		args:             []string{"[config-file]"},
+		help:             "Saves open named backend connections to dawgrun config",
+		desc:             "Writes the currently open connection names and connection strings to config.json.",
+		DisallowRunModes: []RunMode{RunModeCLI},
 
 		Fn: func(ctx *CommandContext, fields []string) error {
 			configPath, err := resolveConfigPath(ctx, fields, "save-connections [config-file]")
@@ -70,8 +73,15 @@ func saveConnectionsCmd() CommandDesc {
 				return err
 			}
 
+			openConnectionConfigs := ctx.scope.GetOpenConnectionConfigs()
+			if len(openConnectionConfigs) == 0 {
+				if err := validateEmptyConnectionSave(configPath); err != nil {
+					return err
+				}
+			}
+
 			config := types.Config{
-				Connections: ctx.scope.GetOpenConnectionConfigs(),
+				Connections: openConnectionConfigs,
 			}
 			if err := config.Save(configPath); err != nil {
 				return err
@@ -81,6 +91,23 @@ func saveConnectionsCmd() CommandDesc {
 			return nil
 		},
 	}
+}
+
+func validateEmptyConnectionSave(configPath string) error {
+	existingConfig, err := types.LoadConfig(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return err
+	}
+
+	if len(existingConfig.Connections) > 0 {
+		return fmt.Errorf("refusing to overwrite %s with no open connections", configPath)
+	}
+
+	return nil
 }
 
 func resolveConfigPath(ctx *CommandContext, fields []string, usage string) (string, error) {

--- a/tools/dawgrun/pkg/commands/config.go
+++ b/tools/dawgrun/pkg/commands/config.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -33,6 +34,8 @@ func loadConnectionsCmd() CommandDesc {
 				return nil
 			}
 
+			var connErrs error
+			openedConns := 0
 			for _, connName := range slices.Sorted(maps.Keys(config.Connections)) {
 				connConfig := config.Connections[connName]
 				driverName, err := openConnection(ctx, connName, connConfig.ConnectionString, openConnectionOptions{
@@ -41,14 +44,16 @@ func loadConnectionsCmd() CommandDesc {
 					quiet:            true,
 				})
 				if err != nil {
-					return fmt.Errorf("could not load connection %s from %s: %w", connName, configPath, err)
+					connErrs = errors.Join(connErrs, fmt.Errorf("could not load connection %s from %s: %w", connName, configPath, err))
+					continue
 				}
 
 				fmt.Fprintf(ctx.output, "Loaded %s connection '%s'\n", driverName, connName)
+				openedConns += 1
 			}
 
-			fmt.Fprintf(ctx.output, "Loaded %d connection(s) from %s\n", len(config.Connections), configPath)
-			return nil
+			fmt.Fprintf(ctx.output, "Loaded %d connection(s) from %s\n", openedConns, configPath)
+			return connErrs
 		},
 	}
 }

--- a/tools/dawgrun/pkg/commands/config.go
+++ b/tools/dawgrun/pkg/commands/config.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"fmt"
+	"maps"
+	"path/filepath"
+	"slices"
+
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
+)
+
+const configFileName = "config.json"
+
+func loadConnectionsCmd() CommandDesc {
+	return CommandDesc{
+		args: []string{"[config-file]"},
+		help: "Loads named backend connections from dawgrun config",
+		desc: "Reads the connections object from config.json, then opens each named connection in the current session.",
+
+		Fn: func(ctx *CommandContext, fields []string) error {
+			configPath, err := resolveConfigPath(ctx, fields, "load-connections [config-file]")
+			if err != nil {
+				return err
+			}
+
+			config, err := types.LoadConfig(configPath)
+			if err != nil {
+				return err
+			}
+
+			if len(config.Connections) == 0 {
+				fmt.Fprintf(ctx.output, "No connections found in %s\n", configPath)
+				return nil
+			}
+
+			for _, connName := range slices.Sorted(maps.Keys(config.Connections)) {
+				connConfig := config.Connections[connName]
+				driverName, err := openConnection(ctx, connName, connConfig.ConnectionString, openConnectionOptions{
+					driverName:       connConfig.Driver,
+					defaultGraphName: "default",
+					quiet:            true,
+				})
+				if err != nil {
+					return fmt.Errorf("could not load connection %s from %s: %w", connName, configPath, err)
+				}
+
+				fmt.Fprintf(ctx.output, "Loaded %s connection '%s'\n", driverName, connName)
+			}
+
+			fmt.Fprintf(ctx.output, "Loaded %d connection(s) from %s\n", len(config.Connections), configPath)
+			return nil
+		},
+	}
+}
+
+func saveConnectionsCmd() CommandDesc {
+	return CommandDesc{
+		args: []string{"[config-file]"},
+		help: "Saves open named backend connections to dawgrun config",
+		desc: "Writes the currently open connection names and connection strings to config.json.",
+
+		Fn: func(ctx *CommandContext, fields []string) error {
+			configPath, err := resolveConfigPath(ctx, fields, "save-connections [config-file]")
+			if err != nil {
+				return err
+			}
+
+			config := types.Config{
+				Connections: ctx.scope.GetOpenConnectionConfigs(),
+			}
+			if err := config.Save(configPath); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(ctx.output, "Saved %d connection(s) to %s\n", len(config.Connections), configPath)
+			return nil
+		},
+	}
+}
+
+func resolveConfigPath(ctx *CommandContext, fields []string, usage string) (string, error) {
+	if len(fields) > 1 {
+		return "", fmt.Errorf("invalid usage: %s", usage)
+	}
+
+	if len(fields) == 1 {
+		return fields[0], nil
+	}
+
+	return filepath.Clean(ctx.defaultConfigPath()), nil
+}

--- a/tools/dawgrun/pkg/commands/config_test.go
+++ b/tools/dawgrun/pkg/commands/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,8 +58,8 @@ func (s *fakeDatabase) RefreshKinds(context.Context) error {
 
 func TestConfigRoundTrip(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
-	expected := Config{
-		Connections: map[string]ConnectionConfig{
+	expected := types.Config{
+		Connections: map[string]types.ConnectionConfig{
 			"local": {
 				Driver:           "pg",
 				ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
@@ -70,9 +71,9 @@ func TestConfigRoundTrip(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, SaveConfig(configPath, expected))
+	require.NoError(t, expected.Save(configPath))
 
-	actual, err := LoadConfig(configPath)
+	actual, err := types.LoadConfig(configPath)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }
@@ -81,9 +82,9 @@ func TestLoadConfigLegacyStringConnections(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	require.NoError(t, os.WriteFile(configPath, []byte(`{"connections":{"local":"postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable"}}`), 0o600))
 
-	actual, err := LoadConfig(configPath)
+	actual, err := types.LoadConfig(configPath)
 	require.NoError(t, err)
-	require.Equal(t, map[string]ConnectionConfig{
+	require.Equal(t, map[string]types.ConnectionConfig{
 		"local": {
 			ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 		},
@@ -91,7 +92,7 @@ func TestLoadConfigLegacyStringConnections(t *testing.T) {
 }
 
 func TestDefaultConfigPath(t *testing.T) {
-	require.Equal(t, filepath.Join("base", "config.json"), DefaultConfigPath("base"))
+	require.Equal(t, filepath.Join("base", "config.json"), types.DefaultConfigPath("base"))
 }
 
 func TestListConnectionsCommandShowsNoConnections(t *testing.T) {
@@ -120,7 +121,7 @@ func TestListConnectionsCommandShowsOpenAndConfiguredUnopenedConnections(t *test
 		"local": "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 		"prod":  "postgres://dawgs:dawgs@prod:5432/dawgs?sslmode=disable",
 	})
-	scope.AddConnection("local", &fakeDatabase{}, ConnectionConfig{
+	scope.AddConnection("local", &fakeDatabase{}, types.ConnectionConfig{
 		Driver:           "pg",
 		ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 	})
@@ -136,7 +137,7 @@ func TestSaveConnectionsCommandWritesOpenConnections(t *testing.T) {
 	scope.SetConnectionStrings(map[string]string{
 		"configured-only": "neo4j://neo4j:password@localhost:7687",
 	})
-	scope.AddConnection("local", &fakeDatabase{}, ConnectionConfig{
+	scope.AddConnection("local", &fakeDatabase{}, types.ConnectionConfig{
 		Driver:           "pg",
 		ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 	})
@@ -144,9 +145,9 @@ func TestSaveConnectionsCommandWritesOpenConnections(t *testing.T) {
 
 	require.NoError(t, saveConnectionsCmd().Fn(ctx, []string{configPath}))
 
-	config, err := LoadConfig(configPath)
+	config, err := types.LoadConfig(configPath)
 	require.NoError(t, err)
-	require.Equal(t, map[string]ConnectionConfig{
+	require.Equal(t, map[string]types.ConnectionConfig{
 		"local": {
 			Driver:           "pg",
 			ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
@@ -169,9 +170,9 @@ func TestSaveConnectionsCommandWritesDriverOverride(t *testing.T) {
 	require.NoError(t, openCmd().Fn(ctx, []string{"-driver", "pg", "schemeless", "host=localhost user=dawgs dbname=dawgs"}))
 	require.NoError(t, saveConnectionsCmd().Fn(ctx, []string{configPath}))
 
-	config, err := LoadConfig(configPath)
+	config, err := types.LoadConfig(configPath)
 	require.NoError(t, err)
-	require.Equal(t, map[string]ConnectionConfig{
+	require.Equal(t, map[string]types.ConnectionConfig{
 		"schemeless": {
 			Driver:           "pg",
 			ConnectionString: "host=localhost user=dawgs dbname=dawgs",
@@ -181,8 +182,8 @@ func TestSaveConnectionsCommandWritesDriverOverride(t *testing.T) {
 
 func TestLoadConnectionsCommandOpensConfiguredConnections(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
-	require.NoError(t, SaveConfig(configPath, Config{
-		Connections: map[string]ConnectionConfig{
+	require.NoError(t, (types.Config{
+		Connections: map[string]types.ConnectionConfig{
 			"local": {
 				ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 			},
@@ -191,7 +192,7 @@ func TestLoadConnectionsCommandOpensConfiguredConnections(t *testing.T) {
 				ConnectionString: "neo4j://neo4j:password@localhost:7687",
 			},
 		},
-	}))
+	}).Save(configPath))
 
 	scope := NewScope()
 	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
@@ -209,7 +210,7 @@ func TestLoadConnectionsCommandOpensConfiguredConnections(t *testing.T) {
 	require.NoError(t, loadConnectionsCmd().Fn(ctx, []string{configPath}))
 
 	require.Equal(t, 2, scope.GetNumConnections())
-	require.Equal(t, map[string]ConnectionConfig{
+	require.Equal(t, map[string]types.ConnectionConfig{
 		"local": {
 			Driver:           "pg",
 			ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
@@ -224,14 +225,14 @@ func TestLoadConnectionsCommandOpensConfiguredConnections(t *testing.T) {
 
 func TestLoadConnectionsCommandPassesStoredDriver(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
-	require.NoError(t, SaveConfig(configPath, Config{
-		Connections: map[string]ConnectionConfig{
+	require.NoError(t, (types.Config{
+		Connections: map[string]types.ConnectionConfig{
 			"schemeless": {
 				Driver:           "pg",
 				ConnectionString: "host=localhost user=dawgs dbname=dawgs",
 			},
 		},
-	}))
+	}).Save(configPath))
 
 	scope := NewScope()
 	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
@@ -243,7 +244,7 @@ func TestLoadConnectionsCommandPassesStoredDriver(t *testing.T) {
 	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
 
 	require.NoError(t, loadConnectionsCmd().Fn(ctx, []string{configPath}))
-	require.Equal(t, map[string]ConnectionConfig{
+	require.Equal(t, map[string]types.ConnectionConfig{
 		"schemeless": {
 			Driver:           "pg",
 			ConnectionString: "host=localhost user=dawgs dbname=dawgs",
@@ -253,7 +254,7 @@ func TestLoadConnectionsCommandPassesStoredDriver(t *testing.T) {
 
 func TestEnsureConnectionOpensConfiguredConnection(t *testing.T) {
 	scope := NewScope()
-	scope.SetConnectionConfigs(map[string]ConnectionConfig{
+	scope.SetConnectionConfigs(map[string]types.ConnectionConfig{
 		"local": {
 			Driver:           "pg",
 			ConnectionString: "host=localhost user=dawgs dbname=dawgs",

--- a/tools/dawgrun/pkg/commands/config_test.go
+++ b/tools/dawgrun/pkg/commands/config_test.go
@@ -96,14 +96,14 @@ func TestDefaultConfigPath(t *testing.T) {
 }
 
 func TestListConnectionsCommandShowsNoConnections(t *testing.T) {
-	ctx := NewCommandContext(context.Background(), nil, NewScope(), t.TempDir())
+	ctx := NewCommandContext(context.Background(), nil, NewScope(RunModeREPL), t.TempDir())
 
 	require.NoError(t, listConnectionsCmd().Fn(ctx, nil))
 	require.Equal(t, "No connections\n", ctx.OutputString())
 }
 
 func TestListConnectionsCommandShowsConfiguredUnopenedConnections(t *testing.T) {
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.SetConnectionStrings(map[string]string{
 		"prod":    "postgres://dawgs:dawgs@prod:5432/dawgs?sslmode=disable",
 		"staging": "postgres://dawgs:dawgs@staging:5432/dawgs?sslmode=disable",
@@ -116,7 +116,7 @@ func TestListConnectionsCommandShowsConfiguredUnopenedConnections(t *testing.T) 
 }
 
 func TestListConnectionsCommandShowsOpenAndConfiguredUnopenedConnections(t *testing.T) {
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.SetConnectionStrings(map[string]string{
 		"local": "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
 		"prod":  "postgres://dawgs:dawgs@prod:5432/dawgs?sslmode=disable",
@@ -133,7 +133,7 @@ func TestListConnectionsCommandShowsOpenAndConfiguredUnopenedConnections(t *test
 
 func TestSaveConnectionsCommandWritesOpenConnections(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.SetConnectionStrings(map[string]string{
 		"configured-only": "neo4j://neo4j:password@localhost:7687",
 	})
@@ -156,9 +156,33 @@ func TestSaveConnectionsCommandWritesOpenConnections(t *testing.T) {
 	require.Contains(t, ctx.OutputString(), "Saved 1 connection(s)")
 }
 
+func TestSaveConnectionsCommandDoesNotOverwriteExistingConfigWithoutOpenConnections(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	expected := types.Config{
+		Connections: map[string]types.ConnectionConfig{
+			"configured-only": {
+				Driver:           "neo4j",
+				ConnectionString: "neo4j://neo4j:password@localhost:7687",
+			},
+		},
+	}
+	require.NoError(t, expected.Save(configPath))
+
+	scope := NewScope(RunModeREPL)
+	scope.SetConnectionConfigs(expected.Connections)
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	err := saveConnectionsCmd().Fn(ctx, []string{configPath})
+	require.ErrorContains(t, err, "refusing to overwrite")
+
+	config, err := types.LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, expected, config)
+}
+
 func TestSaveConnectionsCommandWritesDriverOverride(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
 		require.Equal(t, "host=localhost user=dawgs dbname=dawgs", connStr)
 		require.Equal(t, "pg", options.driverName)
@@ -194,7 +218,7 @@ func TestLoadConnectionsCommandOpensConfiguredConnections(t *testing.T) {
 		},
 	}).Save(configPath))
 
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
 		driverName := options.driverName
 		if driverName == "" {
@@ -234,7 +258,7 @@ func TestLoadConnectionsCommandPassesStoredDriver(t *testing.T) {
 		},
 	}).Save(configPath))
 
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
 		require.Equal(t, "host=localhost user=dawgs dbname=dawgs", connStr)
 		require.Equal(t, "pg", options.driverName)
@@ -253,7 +277,7 @@ func TestLoadConnectionsCommandPassesStoredDriver(t *testing.T) {
 }
 
 func TestEnsureConnectionOpensConfiguredConnection(t *testing.T) {
-	scope := NewScope()
+	scope := NewScope(RunModeREPL)
 	scope.SetConnectionConfigs(map[string]types.ConnectionConfig{
 		"local": {
 			Driver:           "pg",

--- a/tools/dawgrun/pkg/commands/config_test.go
+++ b/tools/dawgrun/pkg/commands/config_test.go
@@ -1,0 +1,279 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDatabase struct {
+	closed bool
+}
+
+func (s *fakeDatabase) SetWriteFlushSize(int) {}
+
+func (s *fakeDatabase) SetBatchWriteSize(int) {}
+
+func (s *fakeDatabase) ReadTransaction(context.Context, graph.TransactionDelegate, ...graph.TransactionOption) error {
+	return nil
+}
+
+func (s *fakeDatabase) WriteTransaction(context.Context, graph.TransactionDelegate, ...graph.TransactionOption) error {
+	return nil
+}
+
+func (s *fakeDatabase) BatchOperation(context.Context, graph.BatchDelegate, ...graph.BatchOption) error {
+	return nil
+}
+
+func (s *fakeDatabase) AssertSchema(context.Context, graph.Schema) error {
+	return nil
+}
+
+func (s *fakeDatabase) SetDefaultGraph(context.Context, graph.Graph) error {
+	return nil
+}
+
+func (s *fakeDatabase) Run(context.Context, string, map[string]any) error {
+	return nil
+}
+
+func (s *fakeDatabase) Close(context.Context) error {
+	s.closed = true
+	return nil
+}
+
+func (s *fakeDatabase) FetchKinds(context.Context) (graph.Kinds, error) {
+	return nil, nil
+}
+
+func (s *fakeDatabase) RefreshKinds(context.Context) error {
+	return nil
+}
+
+func TestConfigRoundTrip(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	expected := Config{
+		Connections: map[string]ConnectionConfig{
+			"local": {
+				Driver:           "pg",
+				ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+			},
+			"neo": {
+				Driver:           "neo4j",
+				ConnectionString: "neo4j://neo4j:password@localhost:7687",
+			},
+		},
+	}
+
+	require.NoError(t, SaveConfig(configPath, expected))
+
+	actual, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestLoadConfigLegacyStringConnections(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"connections":{"local":"postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable"}}`), 0o600))
+
+	actual, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, map[string]ConnectionConfig{
+		"local": {
+			ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+		},
+	}, actual.Connections)
+}
+
+func TestDefaultConfigPath(t *testing.T) {
+	require.Equal(t, filepath.Join("base", "config.json"), DefaultConfigPath("base"))
+}
+
+func TestListConnectionsCommandShowsNoConnections(t *testing.T) {
+	ctx := NewCommandContext(context.Background(), nil, NewScope(), t.TempDir())
+
+	require.NoError(t, listConnectionsCmd().Fn(ctx, nil))
+	require.Equal(t, "No connections\n", ctx.OutputString())
+}
+
+func TestListConnectionsCommandShowsConfiguredUnopenedConnections(t *testing.T) {
+	scope := NewScope()
+	scope.SetConnectionStrings(map[string]string{
+		"prod":    "postgres://dawgs:dawgs@prod:5432/dawgs?sslmode=disable",
+		"staging": "postgres://dawgs:dawgs@staging:5432/dawgs?sslmode=disable",
+	})
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	require.NoError(t, listConnectionsCmd().Fn(ctx, nil))
+	require.Equal(t, "Configured connections (2, unopened):\n  prod\n  staging\n", ctx.OutputString())
+	require.NotContains(t, ctx.OutputString(), "postgres://")
+}
+
+func TestListConnectionsCommandShowsOpenAndConfiguredUnopenedConnections(t *testing.T) {
+	scope := NewScope()
+	scope.SetConnectionStrings(map[string]string{
+		"local": "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+		"prod":  "postgres://dawgs:dawgs@prod:5432/dawgs?sslmode=disable",
+	})
+	scope.AddConnection("local", &fakeDatabase{}, ConnectionConfig{
+		Driver:           "pg",
+		ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+	})
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	require.NoError(t, listConnectionsCmd().Fn(ctx, nil))
+	require.Equal(t, "Open connections (1):\n  local\n\nConfigured connections (1, unopened):\n  prod\n", ctx.OutputString())
+}
+
+func TestSaveConnectionsCommandWritesOpenConnections(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	scope := NewScope()
+	scope.SetConnectionStrings(map[string]string{
+		"configured-only": "neo4j://neo4j:password@localhost:7687",
+	})
+	scope.AddConnection("local", &fakeDatabase{}, ConnectionConfig{
+		Driver:           "pg",
+		ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+	})
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	require.NoError(t, saveConnectionsCmd().Fn(ctx, []string{configPath}))
+
+	config, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, map[string]ConnectionConfig{
+		"local": {
+			Driver:           "pg",
+			ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+		},
+	}, config.Connections)
+	require.Contains(t, ctx.OutputString(), "Saved 1 connection(s)")
+}
+
+func TestSaveConnectionsCommandWritesDriverOverride(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	scope := NewScope()
+	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
+		require.Equal(t, "host=localhost user=dawgs dbname=dawgs", connStr)
+		require.Equal(t, "pg", options.driverName)
+
+		return &fakeDatabase{}, options.driverName, nil
+	}
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	require.NoError(t, openCmd().Fn(ctx, []string{"-driver", "pg", "schemeless", "host=localhost user=dawgs dbname=dawgs"}))
+	require.NoError(t, saveConnectionsCmd().Fn(ctx, []string{configPath}))
+
+	config, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, map[string]ConnectionConfig{
+		"schemeless": {
+			Driver:           "pg",
+			ConnectionString: "host=localhost user=dawgs dbname=dawgs",
+		},
+	}, config.Connections)
+}
+
+func TestLoadConnectionsCommandOpensConfiguredConnections(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, SaveConfig(configPath, Config{
+		Connections: map[string]ConnectionConfig{
+			"local": {
+				ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+			},
+			"neo": {
+				Driver:           "neo4j",
+				ConnectionString: "neo4j://neo4j:password@localhost:7687",
+			},
+		},
+	}))
+
+	scope := NewScope()
+	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
+		driverName := options.driverName
+		if driverName == "" {
+			var err error
+			driverName, err = driverFromConnectionString(connStr)
+			require.NoError(t, err)
+		}
+
+		return &fakeDatabase{}, driverName, nil
+	}
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	require.NoError(t, loadConnectionsCmd().Fn(ctx, []string{configPath}))
+
+	require.Equal(t, 2, scope.GetNumConnections())
+	require.Equal(t, map[string]ConnectionConfig{
+		"local": {
+			Driver:           "pg",
+			ConnectionString: "postgres://dawgs:dawgs@localhost:5432/dawgs?sslmode=disable",
+		},
+		"neo": {
+			Driver:           "neo4j",
+			ConnectionString: "neo4j://neo4j:password@localhost:7687",
+		},
+	}, scope.GetOpenConnectionConfigs())
+	require.Contains(t, ctx.OutputString(), "Loaded 2 connection(s)")
+}
+
+func TestLoadConnectionsCommandPassesStoredDriver(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, SaveConfig(configPath, Config{
+		Connections: map[string]ConnectionConfig{
+			"schemeless": {
+				Driver:           "pg",
+				ConnectionString: "host=localhost user=dawgs dbname=dawgs",
+			},
+		},
+	}))
+
+	scope := NewScope()
+	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
+		require.Equal(t, "host=localhost user=dawgs dbname=dawgs", connStr)
+		require.Equal(t, "pg", options.driverName)
+
+		return &fakeDatabase{}, options.driverName, nil
+	}
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+
+	require.NoError(t, loadConnectionsCmd().Fn(ctx, []string{configPath}))
+	require.Equal(t, map[string]ConnectionConfig{
+		"schemeless": {
+			Driver:           "pg",
+			ConnectionString: "host=localhost user=dawgs dbname=dawgs",
+		},
+	}, scope.GetOpenConnectionConfigs())
+}
+
+func TestEnsureConnectionOpensConfiguredConnection(t *testing.T) {
+	scope := NewScope()
+	scope.SetConnectionConfigs(map[string]ConnectionConfig{
+		"local": {
+			Driver:           "pg",
+			ConnectionString: "host=localhost user=dawgs dbname=dawgs",
+		},
+	})
+
+	opened := 0
+	scope.openDatabase = func(_ context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
+		opened++
+		require.True(t, options.quiet)
+		require.Equal(t, "pg", options.driverName)
+		require.Equal(t, "host=localhost user=dawgs dbname=dawgs", connStr)
+
+		return &fakeDatabase{}, "pg", nil
+	}
+
+	ctx := NewCommandContext(context.Background(), nil, scope, t.TempDir())
+	conn, err := ctx.EnsureConnection("local")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, 1, opened)
+	require.Empty(t, ctx.OutputString())
+}

--- a/tools/dawgrun/pkg/commands/cypher.go
+++ b/tools/dawgrun/pkg/commands/cypher.go
@@ -1,23 +1,19 @@
 package commands
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/kanmu/go-sqlfmt/sqlfmt"
 	"github.com/specterops/dawgs/cypher/models/pgsql/format"
 	"github.com/specterops/dawgs/cypher/models/pgsql/translate"
 	"github.com/specterops/dawgs/drivers/pg"
 	"github.com/specterops/dawgs/graph"
-	"golang.org/x/term"
 
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/stubs"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/texttools"
 )
 
 const (
@@ -132,9 +128,9 @@ func explainAsPsqlCmd() CommandDesc {
 			}
 
 			connName := fields[0]
-			conn, ok := ctx.scope.connections[connName]
-			if !ok {
-				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
+			conn, err := ctx.EnsureConnection(connName)
+			if err != nil {
+				return err
 			}
 
 			// Fetch kinds regardless of if it's already loaded.
@@ -209,7 +205,7 @@ func defaultGraphID(ctx *CommandContext, connName string) int32 {
 		return translate.DefaultGraphID
 	}
 
-	conn, ok := ctx.scope.connections[connName]
+	conn, ok := ctx.scope.GetConnection(connName)
 	if !ok {
 		return translate.DefaultGraphID
 	}
@@ -260,9 +256,9 @@ func queryCypherCmd() CommandDesc {
 			}
 
 			connName := fields[0]
-			conn, ok := ctx.scope.connections[connName]
-			if !ok {
-				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
+			conn, err := ctx.EnsureConnection(connName)
+			if err != nil {
+				return err
 			}
 
 			cypherQuery := strings.Join(fields[1:], " ")
@@ -276,238 +272,13 @@ func queryCypherCmd() CommandDesc {
 
 				switch outputFormat {
 				case queryCypherOutputFormatJSON:
-					return queryCypherOutputJSON(ctx, result)
+					return texttools.CypherOutputJSON(ctx.output, result)
 				case queryCypherOutputFormatTable:
-					return queryCypherOutputTable(ctx, result)
+					return texttools.CypherOutputTable(ctx.output, result)
 				}
 
 				return fmt.Errorf("unknown output format: %s", outputFormat)
 			})
 		},
-	}
-}
-
-func queryCypherOutputJSON(ctx *CommandContext, result graph.Result) error {
-	var outputColumns []string
-
-	fmt.Fprint(ctx.output, "[\n")
-
-	rowCount := 0
-	for result.Next() {
-		values := result.Values()
-		insertFormat := ",\n    %s"
-
-		if rowCount == 0 {
-			outputColumns = buildCypherResultColumns(result.Keys(), len(values))
-			insertFormat = "    %s"
-		}
-
-		rowOutput, err := json.MarshalIndent(buildCypherResultJSONRow(outputColumns, values), "    ", "    ")
-		if err != nil {
-			return fmt.Errorf("error marshalling JSON row: %v: %w", values, err)
-		}
-
-		fmt.Fprintf(ctx.output, insertFormat, rowOutput)
-		rowCount++
-	}
-
-	if err := result.Error(); err != nil {
-		return fmt.Errorf("error fetching query rows: %w", err)
-	}
-
-	fmt.Fprint(ctx.output, "\n]\n")
-
-	return nil
-}
-
-func queryCypherOutputTable(ctx *CommandContext, result graph.Result) error {
-	var (
-		outputColumns []string
-		outputTable   table.Writer
-	)
-
-	outputTable = table.NewWriter()
-	style := table.StyleRounded
-	style.Options.SeparateRows = true
-	style.Size.WidthMax = cypherResultTableWidth()
-	outputTable.SetStyle(style)
-
-	rowCount := 0
-	for result.Next() {
-		values := result.Values()
-
-		if rowCount == 0 {
-			outputColumns = buildCypherResultColumns(result.Keys(), len(values))
-
-			outputTable.AppendHeader(buildCypherResultHeader(outputColumns))
-			outputTable.SetColumnConfigs(buildCypherResultColumnConfigs(len(outputColumns), cypherResultTableWidth()))
-		}
-
-		outputTable.AppendRow(buildCypherResultRow(values))
-		rowCount++
-	}
-
-	if err := result.Error(); err != nil {
-		return fmt.Errorf("error fetching query rows: %w", err)
-	}
-
-	if rowCount == 0 {
-		fmt.Fprint(ctx.output, "(0 rows)\n")
-		return nil
-	}
-
-	fmt.Fprint(ctx.output, outputTable.Render())
-	fmt.Fprintf(ctx.output, "\n(%d rows)\n", rowCount)
-
-	return nil
-}
-
-func cypherResultTableWidth() int {
-	const (
-		fallbackWidth = 120
-	)
-
-	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
-		return width - 2
-	}
-
-	return fallbackWidth
-}
-
-func buildCypherResultColumnConfigs(columnCount, tableWidth int) []table.ColumnConfig {
-	if columnCount == 0 {
-		return nil
-	}
-
-	const (
-		minColumnWidth = 12
-		innerPadding   = 3
-	)
-
-	availableWidth := tableWidth - 1 - (columnCount * innerPadding)
-	columnWidth := availableWidth / columnCount
-	if columnWidth < minColumnWidth {
-		columnWidth = minColumnWidth
-	}
-
-	configs := make([]table.ColumnConfig, 0, columnCount)
-	for idx := 0; idx < columnCount; idx++ {
-		configs = append(configs, table.ColumnConfig{
-			Number:           idx + 1,
-			WidthMax:         columnWidth,
-			WidthMaxEnforcer: text.WrapHard,
-		})
-	}
-
-	return configs
-}
-
-func buildCypherResultColumns(keys []string, numValues int) []string {
-	columns := append([]string{}, keys...)
-
-	if len(columns) < numValues {
-		for idx := len(columns); idx < numValues; idx++ {
-			columns = append(columns, fmt.Sprintf("column_%d", idx+1))
-		}
-	}
-
-	return columns
-}
-
-func buildCypherResultHeader(columns []string) table.Row {
-	row := make(table.Row, len(columns))
-	for idx, key := range columns {
-		row[idx] = key
-	}
-
-	return row
-}
-
-func buildCypherResultJSONRow(columns []string, values []any) map[string]any {
-	row := make(map[string]any, len(columns))
-	for idx, key := range columns {
-		if idx < len(values) {
-			row[key] = formatCypherResultJSONValue(values[idx])
-		} else {
-			row[key] = nil
-		}
-	}
-
-	return row
-}
-
-func formatCypherResultJSONValue(value any) any {
-	switch typed := value.(type) {
-	case nil:
-		return nil
-	case bool,
-		int,
-		int8,
-		int16,
-		int32,
-		int64,
-		uint,
-		uint8,
-		uint16,
-		uint32,
-		uint64,
-		float32,
-		float64,
-		string:
-		return typed
-	case graph.ID:
-		return typed.Uint64()
-	case []byte:
-		return string(typed)
-	default:
-		if marshaled, err := json.Marshal(typed); err == nil {
-			var normalized any
-			if err := json.Unmarshal(marshaled, &normalized); err == nil {
-				return normalized
-			}
-		}
-
-		return fmt.Sprintf("%v", typed)
-	}
-}
-
-func buildCypherResultRow(values []any) table.Row {
-	row := make(table.Row, len(values))
-	for idx, value := range values {
-		row[idx] = formatCypherResultValue(value)
-	}
-
-	return row
-}
-
-func formatCypherResultValue(value any) any {
-	switch typed := value.(type) {
-	case nil:
-		return "<nil>"
-	case bool,
-		int,
-		int8,
-		int16,
-		int32,
-		int64,
-		uint,
-		uint8,
-		uint16,
-		uint32,
-		uint64,
-		float32,
-		float64,
-		string:
-		return typed
-	case []byte:
-		return string(typed)
-	case fmt.Stringer:
-		return typed.String()
-	default:
-		if marshaled, err := json.Marshal(typed); err == nil {
-			return string(marshaled)
-		}
-
-		return fmt.Sprintf("%v", typed)
 	}
 }

--- a/tools/dawgrun/pkg/commands/db.go
+++ b/tools/dawgrun/pkg/commands/db.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/url"
@@ -15,28 +16,43 @@ import (
 	"github.com/specterops/dawgs/graph"
 
 	"github.com/specterops/dawgs/tools/dawgrun/pkg/stubs"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/types"
 )
 
 func listConnectionsCmd() CommandDesc {
 	return CommandDesc{
 		args: []string{},
-		help: "Lists currently open named connections",
-		desc: "Prints all active connection names for this REPL session.",
+		help: "Lists open and configured named connections",
+		desc: "Prints open connection names and configured connection names that have not been opened yet.",
 
 		Fn: func(ctx *CommandContext, fields []string) error {
 			if len(fields) != 0 {
 				return fmt.Errorf("invalid usage: list-connections")
 			}
 
-			connNames := ctx.scope.GetConnectionNames()
-			if len(connNames) == 0 {
-				fmt.Fprintln(ctx.output, "No open connections")
+			openConnNames := ctx.scope.GetConnectionNames()
+			unopenedConnNames := ctx.scope.GetUnopenedConnectionNames()
+			if len(openConnNames) == 0 && len(unopenedConnNames) == 0 {
+				fmt.Fprintln(ctx.output, "No connections")
 				return nil
 			}
 
-			fmt.Fprintf(ctx.output, "Open connections (%d):\n", len(connNames))
-			for _, connName := range connNames {
-				fmt.Fprintf(ctx.output, "  %s\n", connName)
+			if len(openConnNames) > 0 {
+				fmt.Fprintf(ctx.output, "Open connections (%d):\n", len(openConnNames))
+				for _, connName := range openConnNames {
+					fmt.Fprintf(ctx.output, "  %s\n", connName)
+				}
+			}
+
+			if len(openConnNames) > 0 && len(unopenedConnNames) > 0 {
+				fmt.Fprint(ctx.output, "\n")
+			}
+
+			if len(unopenedConnNames) > 0 {
+				fmt.Fprintf(ctx.output, "Configured connections (%d, unopened):\n", len(unopenedConnNames))
+				for _, connName := range unopenedConnNames {
+					fmt.Fprintf(ctx.output, "  %s\n", connName)
+				}
 			}
 
 			return nil
@@ -81,79 +97,120 @@ func openCmd() CommandDesc {
 			name := fields[0]
 			connStr := fields[1]
 
-			driverName := ""
 			if strings.TrimSpace(driverOverride) != "" {
-				driverName = strings.ToLower(strings.TrimSpace(driverOverride))
-			} else if detectedDriverName, err := driverFromConnectionString(connStr); err != nil {
-				return err
-			} else {
-				driverName = detectedDriverName
+				driverOverride = strings.ToLower(strings.TrimSpace(driverOverride))
 			}
 
-			config := dawgs.Config{
-				ConnectionString: connStr,
-			}
-
-			openSuccess := false
-			switch driverName {
-			case pg.DriverName:
-				connPool, err := pg.NewPool(drivers.DatabaseConfiguration{
-					Connection: connStr,
-				})
-				if err != nil {
-					return fmt.Errorf("error opening connection pool: %w", err)
-				}
-				defer func() {
-					if !openSuccess {
-						connPool.Close()
-					}
-				}()
-
-				config.Pool = connPool
-			case neo4j.DriverName:
-				// No additional setup required for Neo4j before dawgs.Open.
-			default:
-				return fmt.Errorf("unsupported driver %q; expected one of: %s, %s", driverName, pg.DriverName, neo4j.DriverName)
-			}
-
-			querier, err := dawgs.Open(ctx, driverName, config)
+			_, err := openConnection(ctx, name, connStr, openConnectionOptions{
+				driverName:       driverOverride,
+				defaultGraphName: defaultGraphName,
+				initGraphOnFail:  initGraphOnFail,
+			})
 			if err != nil {
-				return fmt.Errorf("error opening %s database connection '%s': %w", driverName, connStr, err)
+				return err
 			}
-
-			defaultGraph := graph.Graph{Name: defaultGraphName}
-			if err := querier.SetDefaultGraph(ctx, defaultGraph); err != nil {
-				if !initGraphOnFail {
-					return fmt.Errorf("could not set default graph: %w", err)
-				}
-
-				graphSchema := graph.Schema{
-					Graphs:       []graph.Graph{defaultGraph},
-					DefaultGraph: defaultGraph,
-				}
-				if err := querier.AssertSchema(ctx, graphSchema); err != nil {
-					return fmt.Errorf("could not initialize graph schema: %w", err)
-				}
-			}
-
-			if existingConn, ok := ctx.scope.GetConnection(name); ok {
-				// Warn+close existing connection before overwriting it
-				ctx.output.Warnf("Discarding previous connection for '%s'", name)
-				if err := existingConn.Close(ctx); err != nil {
-					return fmt.Errorf("could not close previous connection '%s' for overwriting: %w", name, err)
-				}
-
-				// Wipe out handles and resources for this connection
-				ctx.scope.DropConnection(name)
-			}
-
-			fmt.Fprintf(ctx.output, "Opened %s connection '%s'\n", driverName, name)
-			ctx.scope.AddConnection(name, querier)
-			openSuccess = true
 
 			return nil
 		},
 	}
+}
+
+func openConnection(ctx *CommandContext, name string, connStr string, options openConnectionOptions) (string, error) {
+	querier, driverName, err := ctx.scope.openDatabase(ctx, connStr, options)
+	if err != nil {
+		return "", err
+	}
+	if existingConn, ok := ctx.scope.GetConnection(name); ok {
+		ctx.output.Warnf("Discarding previous connection for '%s'", name)
+		if err := existingConn.Close(ctx); err != nil {
+			_ = querier.Close(ctx)
+			return "", fmt.Errorf("could not close previous connection '%s' for overwriting: %w", name, err)
+		}
+		ctx.scope.DropConnection(name)
+	}
+
+	ctx.scope.AddConnection(name, querier, types.ConnectionConfig{
+		Driver:           driverName,
+		ConnectionString: connStr,
+	})
+	if !options.quiet {
+		fmt.Fprintf(ctx.output, "Opened %s connection '%s'\n", driverName, name)
+	}
+
+	return driverName, nil
+}
+
+func openDAWGSDatabase(ctx context.Context, connStr string, options openConnectionOptions) (graph.Database, string, error) {
+	driverName := strings.TrimSpace(options.driverName)
+	if driverName == "" {
+		detectedDriverName, err := driverFromConnectionString(connStr)
+		if err != nil {
+			return nil, "", err
+		}
+
+		driverName = detectedDriverName
+	}
+
+	if options.defaultGraphName == "" {
+		options.defaultGraphName = "default"
+	}
+
+	config := dawgs.Config{
+		ConnectionString: connStr,
+	}
+
+	poolOwnedByDriver := false
+	switch driverName {
+	case pg.DriverName:
+		connPool, err := pg.NewPool(drivers.DatabaseConfiguration{
+			Connection: connStr,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("error opening connection pool: %w", err)
+		}
+		defer func() {
+			if !poolOwnedByDriver {
+				connPool.Close()
+			}
+		}()
+
+		config.Pool = connPool
+	case neo4j.DriverName:
+		// No additional setup required for Neo4j before dawgs.Open.
+	default:
+		return nil, "", fmt.Errorf("unsupported driver %q; expected one of: %s, %s", driverName, pg.DriverName, neo4j.DriverName)
+	}
+
+	querier, err := dawgs.Open(ctx, driverName, config)
+	if err != nil {
+		return nil, "", fmt.Errorf("error opening %s database connection '%s': %w", driverName, connStr, err)
+	}
+	poolOwnedByDriver = true
+
+	openSuccess := false
+	defer func() {
+		if !openSuccess {
+			_ = querier.Close(ctx)
+		}
+	}()
+
+	defaultGraph := graph.Graph{Name: options.defaultGraphName}
+	if err := querier.SetDefaultGraph(ctx, defaultGraph); err != nil {
+		if !options.initGraphOnFail {
+			return nil, "", fmt.Errorf("could not set default graph: %w", err)
+		}
+
+		graphSchema := graph.Schema{
+			Graphs:       []graph.Graph{defaultGraph},
+			DefaultGraph: defaultGraph,
+		}
+		if err := querier.AssertSchema(ctx, graphSchema); err != nil {
+			return nil, "", fmt.Errorf("could not initialize graph schema: %w", err)
+		}
+	}
+
+	openSuccess = true
+	return querier, driverName, nil
 }
 
 func driverFromConnectionString(connStr string) (string, error) {
@@ -197,9 +254,9 @@ func getPGDBKinds() CommandDesc {
 }
 
 func loadKindMap(ctx *CommandContext, connName string) (stubs.KindMap, error) {
-	conn, ok := ctx.scope.GetConnection(connName)
-	if !ok {
-		return nil, fmt.Errorf("unknown connection %s; did you `open` it?", connName)
+	conn, err := ctx.EnsureConnection(connName)
+	if err != nil {
+		return nil, err
 	}
 
 	// Force a refresh from the database backend

--- a/tools/dawgrun/pkg/commands/db.go
+++ b/tools/dawgrun/pkg/commands/db.go
@@ -183,7 +183,7 @@ func openDAWGSDatabase(ctx context.Context, connStr string, options openConnecti
 
 	querier, err := dawgs.Open(ctx, driverName, config)
 	if err != nil {
-		return nil, "", fmt.Errorf("error opening %s database connection '%s': %w", driverName, connStr, err)
+		return nil, "", fmt.Errorf("error opening %s database connection: %w", driverName, err)
 	}
 	poolOwnedByDriver = true
 

--- a/tools/dawgrun/pkg/commands/help.go
+++ b/tools/dawgrun/pkg/commands/help.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/go-wordwrap"
+	"github.com/specterops/dawgs/tools/dawgrun/pkg/texttools"
 )
 
 func getFlagSetHelpDetails(flagSet *flag.FlagSet) string {
@@ -49,32 +50,45 @@ func helpCmd() CommandDesc {
 					spacerPad := strings.Repeat(" ", len(commandLeft))
 					fmt.Fprintf(ctx.output, "%s%s%s\n", commandLeft, spacerPad, cmd.help)
 				}
+			} else if strings.ToLower(fields[0]) == "all" {
+				// ALL COMMAND HELP
+				for name, cmd := range cmdRegistry {
+					fmt.Fprintf(ctx.output, "%s", renderHelp(name, cmd))
+				}
 			} else {
-				// COMMAND HELP
+				// INDIVIDUAL COMMAND HELP
 				name := fields[0]
 				cmd, ok := cmdRegistry[name]
 				if !ok {
 					return fmt.Errorf("unknown command: %s", name)
 				}
 
-				wrappedHelp := indentLines(wordwrap.WrapString(cmd.help, 80), 1)
-				fmt.Fprintf(ctx.output, "\nHELP: %s %s\n\n", name, strings.Join(cmd.args, " "))
-				fmt.Fprintf(ctx.output, "%s\n", wrappedHelp)
-				if strings.TrimSpace(cmd.desc) != "" {
-					fmt.Fprint(ctx.output, "\n")
-					fmt.Fprintf(ctx.output, "%s\n", indentLines(wordwrap.WrapString(cmd.desc, 80), 1))
-				}
-				if cmd.flags != nil {
-					flagDefaults := getFlagSetHelpDetails(cmd.flags)
-					fmt.Fprintf(ctx.output, "\n%s\n%s\n",
-						indentLines("flags:", 1),
-						indentLines(wordwrap.WrapString(flagDefaults, 80), 2),
-					)
-				}
-				fmt.Fprint(ctx.output, "END HELP\n")
+				fmt.Fprintf(ctx.output, "%s", renderHelp(name, cmd))
 			}
 
 			return nil
 		},
 	}
+}
+
+func renderHelp(name string, cmd CommandDesc) string {
+	builder := new(strings.Builder)
+
+	wrappedHelp := texttools.IndentLines(wordwrap.WrapString(cmd.help, 80), 1)
+	fmt.Fprintf(builder, "\nHELP: %s %s\n\n", name, strings.Join(cmd.args, " "))
+	fmt.Fprintf(builder, "%s\n", wrappedHelp)
+	if strings.TrimSpace(cmd.desc) != "" {
+		fmt.Fprint(builder, "\n")
+		fmt.Fprintf(builder, "%s\n", texttools.IndentLines(wordwrap.WrapString(cmd.desc, 80), 1))
+	}
+	if cmd.flags != nil {
+		flagDefaults := getFlagSetHelpDetails(cmd.flags)
+		fmt.Fprintf(builder, "\n%s\n%s\n",
+			texttools.IndentLines("flags:", 1),
+			texttools.IndentLines(wordwrap.WrapString(flagDefaults, 80), 2),
+		)
+	}
+	fmt.Fprint(builder, "END HELP\n")
+
+	return builder.String()
 }

--- a/tools/dawgrun/pkg/commands/help.go
+++ b/tools/dawgrun/pkg/commands/help.go
@@ -40,26 +40,35 @@ func helpCmd() CommandDesc {
 
 				sortedCommands := slices.Sorted(maps.Keys(cmdRegistry))
 				for _, name := range sortedCommands {
+					cmd := cmdRegistry[name]
+					if slices.Contains(cmd.DisallowRunModes, ctx.scope.GetRunMode()) {
+						continue
+					}
+
 					commandLeft := fmt.Sprintf(
 						"%s%s%s",
 						strings.Repeat(" ", 4),
 						name,
 						strings.Repeat(" ", maxNameLength-(len(name))),
 					)
-					cmd := cmdRegistry[name]
 					spacerPad := strings.Repeat(" ", len(commandLeft))
 					fmt.Fprintf(ctx.output, "%s%s%s\n", commandLeft, spacerPad, cmd.help)
 				}
 			} else if strings.ToLower(fields[0]) == "all" {
 				// ALL COMMAND HELP
 				for name, cmd := range cmdRegistry {
+					// skip commands that are disabled for this run mode
+					if slices.Contains(cmd.DisallowRunModes, ctx.scope.GetRunMode()) {
+						continue
+					}
+
 					fmt.Fprintf(ctx.output, "%s", renderHelp(name, cmd))
 				}
 			} else {
 				// INDIVIDUAL COMMAND HELP
 				name := fields[0]
 				cmd, ok := cmdRegistry[name]
-				if !ok {
+				if !ok || slices.Contains(cmd.DisallowRunModes, ctx.scope.GetRunMode()) {
 					return fmt.Errorf("unknown command: %s", name)
 				}
 

--- a/tools/dawgrun/pkg/commands/helpers.go
+++ b/tools/dawgrun/pkg/commands/helpers.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/alecthomas/chroma/v2/quick"
 	cypherFrontend "github.com/specterops/dawgs/cypher/frontend"
 	cypherModels "github.com/specterops/dawgs/cypher/models/cypher"
 )
@@ -12,22 +10,4 @@ import (
 func parseQueryArray(fields []string) (*cypherModels.RegularQuery, error) {
 	cypherCtx := cypherFrontend.DefaultCypherContext()
 	return cypherFrontend.ParseCypher(cypherCtx, strings.Join(fields, " "))
-}
-
-func indentLines(text string, indentCount int) string {
-	builder := new(strings.Builder)
-	for line := range strings.Lines(text) {
-		fmt.Fprintf(builder, "%s%s", strings.Repeat("\t", indentCount), line)
-	}
-
-	return builder.String()
-}
-
-func highlightText(text, lexer, style string) (string, error) {
-	builder := new(strings.Builder)
-	if err := quick.Highlight(builder, text, lexer, "terminal256", style); err != nil {
-		return "", fmt.Errorf("could not highlight source text: %w", err)
-	}
-
-	return builder.String(), nil
 }

--- a/tools/dawgrun/pkg/commands/opengraph.go
+++ b/tools/dawgrun/pkg/commands/opengraph.go
@@ -39,9 +39,9 @@ func saveOpenGraphCmd() CommandDesc {
 			}
 
 			connName := fields[0]
-			conn, ok := ctx.scope.GetConnection(connName)
-			if !ok {
-				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
+			conn, err := ctx.EnsureConnection(connName)
+			if err != nil {
+				return err
 			}
 
 			exportBuffer := new(bytes.Buffer)
@@ -89,9 +89,9 @@ func loadOpenGraphCmd() CommandDesc {
 			connName := fields[0]
 			inputFilePath := fields[1]
 
-			conn, ok := ctx.scope.GetConnection(connName)
-			if !ok {
-				return fmt.Errorf("connection %s not found; did you `open` it?", connName)
+			conn, err := ctx.EnsureConnection(connName)
+			if err != nil {
+				return err
 			}
 
 			inputFile, err := os.Open(inputFilePath)
@@ -132,14 +132,14 @@ func copyOpenGraphCmd() CommandDesc {
 				return fmt.Errorf("source and destination connections must differ")
 			}
 
-			fromConn, ok := ctx.scope.GetConnection(fromConnName)
-			if !ok {
-				return fmt.Errorf("connection %s not found; did you `open` it?", fromConnName)
+			fromConn, err := ctx.EnsureConnection(fromConnName)
+			if err != nil {
+				return err
 			}
 
-			toConn, ok := ctx.scope.GetConnection(toConnName)
-			if !ok {
-				return fmt.Errorf("connection %s not found; did you `open` it?", toConnName)
+			toConn, err := ctx.EnsureConnection(toConnName)
+			if err != nil {
+				return err
 			}
 
 			pipeReader, pipeWriter := io.Pipe()

--- a/tools/dawgrun/pkg/commands/registry.go
+++ b/tools/dawgrun/pkg/commands/registry.go
@@ -11,6 +11,7 @@ var cmdRegistry map[string]CommandDesc = map[string]CommandDesc{
 	"exit":             quitCmd(),
 	"explain-psql":     explainAsPsqlCmd(),
 	"list-connections": listConnectionsCmd(),
+	"load-connections": loadConnectionsCmd(),
 	"load-opengraph":   loadOpenGraphCmd(),
 	"load-db-kinds":    getPGDBKinds(),
 	"lookup-kind":      lookupKindCmd(),
@@ -20,6 +21,7 @@ var cmdRegistry map[string]CommandDesc = map[string]CommandDesc{
 	"query-cypher":     queryCypherCmd(),
 	"quit":             quitCmd(),
 	"runtime-trace":    runtimeTraceCmd(),
+	"save-connections": saveConnectionsCmd(),
 	"save-opengraph":   saveOpenGraphCmd(),
 	"translate-psql":   translateToPsqlCmd(),
 }

--- a/tools/dawgrun/pkg/commands/runtime.go
+++ b/tools/dawgrun/pkg/commands/runtime.go
@@ -9,13 +9,13 @@ import (
 
 func quitCmd() CommandDesc {
 	return CommandDesc{
-		args: []string{},
-		help: "Quit",
-		desc: "Exits the REPL session",
+		args:             []string{},
+		help:             "Quit",
+		desc:             "Exits the REPL session",
+		DisallowRunModes: []RunMode{RunModeCLI},
 
 		Fn: func(ctx *CommandContext, fields []string) error {
 			if ctx.instance == nil {
-				// Bail, it's CLI mode
 				return nil
 			}
 
@@ -37,6 +37,7 @@ func runtimeTraceCmd() CommandDesc {
 		help: "Manage runtime tracing",
 		desc: `start [tracefile] - Start tracing with output to [tracefile] if provided, otherwise trace.out
 stop - Stop runtime tracing and close the trace file`,
+		DisallowRunModes: []RunMode{RunModeCLI},
 
 		Fn: func(ctx *CommandContext, fields []string) error {
 			if len(fields) == 0 {

--- a/tools/dawgrun/pkg/commands/runtime.go
+++ b/tools/dawgrun/pkg/commands/runtime.go
@@ -14,6 +14,11 @@ func quitCmd() CommandDesc {
 		desc: "Exits the REPL session",
 
 		Fn: func(ctx *CommandContext, fields []string) error {
+			if ctx.instance == nil {
+				// Bail, it's CLI mode
+				return nil
+			}
+
 			ctx.instance.Quit()
 			return nil
 		},

--- a/tools/dawgrun/pkg/texttools/cypher.go
+++ b/tools/dawgrun/pkg/texttools/cypher.go
@@ -1,0 +1,239 @@
+package texttools
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/specterops/dawgs/graph"
+)
+
+func CypherOutputJSON(output io.Writer, result graph.Result) error {
+	var outputColumns []string
+
+	fmt.Fprint(output, "[\n")
+
+	rowCount := 0
+	for result.Next() {
+		values := result.Values()
+		insertFormat := ",\n    %s"
+
+		if rowCount == 0 {
+			outputColumns = buildCypherResultColumns(result.Keys(), len(values))
+			insertFormat = "    %s"
+		}
+
+		rowOutput, err := json.MarshalIndent(buildCypherResultJSONRow(outputColumns, values), "    ", "    ")
+		if err != nil {
+			return fmt.Errorf("error marshalling JSON row: %v: %w", values, err)
+		}
+
+		fmt.Fprintf(output, insertFormat, rowOutput)
+		rowCount++
+	}
+
+	if err := result.Error(); err != nil {
+		return fmt.Errorf("error fetching query rows: %w", err)
+	}
+
+	fmt.Fprint(output, "\n]\n")
+
+	return nil
+}
+
+func CypherOutputTable(output io.Writer, result graph.Result) error {
+	var (
+		outputColumns []string
+		outputTable   table.Writer
+	)
+
+	outputTable = table.NewWriter()
+	style := table.StyleRounded
+	style.Options.SeparateRows = true
+	style.Size.WidthMax = cypherResultTableWidth()
+	outputTable.SetStyle(style)
+
+	rowCount := 0
+	for result.Next() {
+		values := result.Values()
+
+		if rowCount == 0 {
+			outputColumns = buildCypherResultColumns(result.Keys(), len(values))
+
+			outputTable.AppendHeader(buildCypherResultHeader(outputColumns))
+			outputTable.SetColumnConfigs(buildCypherResultColumnConfigs(len(outputColumns), cypherResultTableWidth()))
+		}
+
+		outputTable.AppendRow(buildCypherResultRow(values))
+		rowCount++
+	}
+
+	if err := result.Error(); err != nil {
+		return fmt.Errorf("error fetching query rows: %w", err)
+	}
+
+	if rowCount == 0 {
+		fmt.Fprint(output, "(0 rows)\n")
+		return nil
+	}
+
+	fmt.Fprint(output, outputTable.Render())
+	fmt.Fprintf(output, "\n(%d rows)\n", rowCount)
+
+	return nil
+}
+
+func cypherResultTableWidth() int {
+	const (
+		fallbackWidth = 120
+	)
+
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		return width - 2
+	}
+
+	return fallbackWidth
+}
+
+func buildCypherResultColumnConfigs(columnCount, tableWidth int) []table.ColumnConfig {
+	if columnCount == 0 {
+		return nil
+	}
+
+	const (
+		minColumnWidth = 12
+		innerPadding   = 3
+	)
+
+	availableWidth := tableWidth - 1 - (columnCount * innerPadding)
+	columnWidth := availableWidth / columnCount
+	if columnWidth < minColumnWidth {
+		columnWidth = minColumnWidth
+	}
+
+	configs := make([]table.ColumnConfig, 0, columnCount)
+	for idx := 0; idx < columnCount; idx++ {
+		configs = append(configs, table.ColumnConfig{
+			Number:           idx + 1,
+			WidthMax:         columnWidth,
+			WidthMaxEnforcer: text.WrapHard,
+		})
+	}
+
+	return configs
+}
+
+func buildCypherResultColumns(keys []string, numValues int) []string {
+	columns := append([]string{}, keys...)
+
+	if len(columns) < numValues {
+		for idx := len(columns); idx < numValues; idx++ {
+			columns = append(columns, fmt.Sprintf("column_%d", idx+1))
+		}
+	}
+
+	return columns
+}
+
+func buildCypherResultHeader(columns []string) table.Row {
+	row := make(table.Row, len(columns))
+	for idx, key := range columns {
+		row[idx] = key
+	}
+
+	return row
+}
+
+func buildCypherResultJSONRow(columns []string, values []any) map[string]any {
+	row := make(map[string]any, len(columns))
+	for idx, key := range columns {
+		if idx < len(values) {
+			row[key] = formatCypherResultJSONValue(values[idx])
+		} else {
+			row[key] = nil
+		}
+	}
+
+	return row
+}
+
+func formatCypherResultJSONValue(value any) any {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case bool,
+		int,
+		int8,
+		int16,
+		int32,
+		int64,
+		uint,
+		uint8,
+		uint16,
+		uint32,
+		uint64,
+		float32,
+		float64,
+		string:
+		return typed
+	case graph.ID:
+		return typed.Uint64()
+	case []byte:
+		return string(typed)
+	default:
+		if marshaled, err := json.Marshal(typed); err == nil {
+			var normalized any
+			if err := json.Unmarshal(marshaled, &normalized); err == nil {
+				return normalized
+			}
+		}
+
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func buildCypherResultRow(values []any) table.Row {
+	row := make(table.Row, len(values))
+	for idx, value := range values {
+		row[idx] = formatCypherResultValue(value)
+	}
+
+	return row
+}
+
+func formatCypherResultValue(value any) any {
+	switch typed := value.(type) {
+	case nil:
+		return "<nil>"
+	case bool,
+		int,
+		int8,
+		int16,
+		int32,
+		int64,
+		uint,
+		uint8,
+		uint16,
+		uint32,
+		uint64,
+		float32,
+		float64,
+		string:
+		return typed
+	case []byte:
+		return string(typed)
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		if marshaled, err := json.Marshal(typed); err == nil {
+			return string(marshaled)
+		}
+
+		return fmt.Sprintf("%v", typed)
+	}
+}

--- a/tools/dawgrun/pkg/texttools/style.go
+++ b/tools/dawgrun/pkg/texttools/style.go
@@ -1,0 +1,26 @@
+package texttools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/chroma/v2/quick"
+)
+
+func IndentLines(text string, indentCount int) string {
+	builder := new(strings.Builder)
+	for line := range strings.Lines(text) {
+		fmt.Fprintf(builder, "%s%s", strings.Repeat("\t", indentCount), line)
+	}
+
+	return builder.String()
+}
+
+func HighlightText(text, lexer, style string) (string, error) {
+	builder := new(strings.Builder)
+	if err := quick.Highlight(builder, text, lexer, "terminal256", style); err != nil {
+		return "", fmt.Errorf("could not highlight source text: %w", err)
+	}
+
+	return builder.String(), nil
+}

--- a/tools/dawgrun/pkg/types/config.go
+++ b/tools/dawgrun/pkg/types/config.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const DefaultConfigFileName = "config.json"
+
+type Config struct {
+	Connections map[string]ConnectionConfig `json:"connections"`
+}
+
+type ConnectionConfig struct {
+	Driver           string `json:"driver,omitempty"`
+	ConnectionString string `json:"connection_string"`
+}
+
+func LoadConfig(configPath string) (Config, error) {
+	contents, err := os.ReadFile(configPath)
+	if err != nil {
+		return Config{}, fmt.Errorf("could not read config file %s: %w", configPath, err)
+	}
+
+	config := Config{}
+	if err := json.Unmarshal(contents, &config); err != nil {
+		return Config{}, fmt.Errorf("could not parse config file %s: %w", configPath, err)
+	}
+
+	if config.Connections == nil {
+		config.Connections = make(map[string]ConnectionConfig)
+	}
+
+	return config, nil
+}
+
+func (config Config) Save(configPath string) error {
+	if config.Connections == nil {
+		config.Connections = make(map[string]ConnectionConfig)
+	}
+
+	contents, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not marshal config: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		return fmt.Errorf("could not create config directory for %s: %w", configPath, err)
+	}
+
+	contents = append(contents, '\n')
+	if err := os.WriteFile(configPath, contents, 0o600); err != nil {
+		return fmt.Errorf("could not write config file %s: %w", configPath, err)
+	}
+
+	return nil
+}
+
+func (s *ConnectionConfig) UnmarshalJSON(contents []byte) error {
+	var legacyConnectionString string
+	if err := json.Unmarshal(contents, &legacyConnectionString); err == nil {
+		s.ConnectionString = legacyConnectionString
+		s.Driver = ""
+		return nil
+	}
+
+	type connectionConfig ConnectionConfig
+	var config connectionConfig
+	if err := json.Unmarshal(contents, &config); err != nil {
+		return err
+	}
+
+	s.ConnectionString = config.ConnectionString
+	s.Driver = strings.ToLower(strings.TrimSpace(config.Driver))
+	return nil
+}
+
+func DefaultConfigPath(appConfigBaseDir string) string {
+	return filepath.Join(appConfigBaseDir, DefaultConfigFileName)
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly explain the change and its motivation. -->
Adds a CLI mode to dawgrun, enabling users (and agents) to run queries, copy datasets, etc. 
Note that this does not have any changes in the production path.

## Type of Change

- [X] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [X] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [ ] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot CLI mode alongside the interactive REPL; CLI reads config when present.
  * Save/load named backend connections with new save-connections / load-connections commands.
  * Config file support with sample format and default path.
  * Query output: JSON or table rendering with improved formatting.
  * Optional styled (ANSI) output can be disabled for non-terminal output.

* **Documentation**
  * README and RFC updated with CLI/REPL, commands, config, and styling notes.

* **Tests**
  * New unit tests covering CLI/REPL command execution, config persistence, connections, and styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/DAWGS/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->