### PR TITLE
fix: handle self referencing relationships and add panic guards BED-8245

### DIFF
--- a/cypher/models/pgsql/translate/constraints.go
+++ b/cypher/models/pgsql/translate/constraints.go
@@ -448,9 +448,16 @@ func (s *PatternConstraints) OptimizePatternConstraintBalance(scope *Scope, trav
 	}
 
 	if traversalStep.RightNodeBound {
-		// Right is the tighter anchor by definition; flip once to normalize it to the left.
-		traversalStep.FlipNodes()
-		s.FlipNodes()
+		// Only flip when a previous frame exists to serve as the FROM source for the
+		// now-left bound node.  In self-referential patterns such as (u)-[]->(u) the
+		// right node is "bound" because it reuses the left node's variable, but there
+		// is no preceding CTE to reference.  Flipping in that case would set
+		// LeftNodeBound = true while Frame.Previous is nil, causing a nil-pointer
+		// dereference in buildTraversalPatternRoot.
+		if traversalStep.hasPreviousFrameBinding() {
+			traversalStep.FlipNodes()
+			s.FlipNodes()
+		}
 
 		return nil
 	}

--- a/cypher/models/pgsql/translate/expansion.go
+++ b/cypher/models/pgsql/translate/expansion.go
@@ -2,6 +2,7 @@ package translate
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/specterops/dawgs/cypher/models"
 	"github.com/specterops/dawgs/cypher/models/pgsql"
@@ -2013,6 +2014,10 @@ func (s *Translator) buildExpansionPatternRoot(traversalStepContext TraversalSte
 	var seed *expansionSeed
 
 	if traversalStep.LeftNodeBound {
+		if traversalStep.Frame.Previous == nil {
+			return pgsql.Query{}, fmt.Errorf("left node is marked as bound but there is no previous frame to reference")
+		}
+
 		boundSeed := newExpansionBoundNodeSeed(seedIdentifier, traversalStep.Frame.Previous, traversalStep.LeftNode.Identifier, seedConstraints)
 		seed = &boundSeed
 		expansion.UseUnionAll = true

--- a/cypher/models/pgsql/translate/predicate_test.go
+++ b/cypher/models/pgsql/translate/predicate_test.go
@@ -139,3 +139,40 @@ func TestNegatedDynamicStringPredicatesCoalescePropertyLookups(t *testing.T) {
 		})
 	}
 }
+
+func TestSelfReferentialPatternDoesNotPanic(t *testing.T) {
+	kindMapper := pgutil.NewInMemoryKindMapper()
+
+	for _, testCase := range []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "self-referential directed with path binding",
+			query: `match p = (u)-[]->(u) return p`,
+		},
+		{
+			name:  "self-referential directed without path binding",
+			query: `match (u)-[]->(u) return u`,
+		},
+		{
+			name:  "self-referential undirected with path binding",
+			query: `match p = (u)-[]-(u) return p`,
+		},
+		{
+			name:  "self-referential expansion",
+			query: `match p = (u)-[*1..3]->(u) return p`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			query, err := frontend.ParseCypher(frontend.NewContext(), testCase.query)
+			require.NoError(t, err)
+
+			translation, err := Translate(context.Background(), query, kindMapper, nil, DefaultGraphID)
+			require.NoError(t, err)
+
+			_, err = Translated(translation)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/cypher/models/pgsql/translate/traversal.go
+++ b/cypher/models/pgsql/translate/traversal.go
@@ -28,6 +28,10 @@ func (s *Translator) buildDirectionlessTraversalPatternRoot(traversalStep *Trave
 	)
 
 	if traversalStep.LeftNodeBound {
+		if traversalStep.Frame.Previous == nil {
+			return pgsql.Query{}, fmt.Errorf("left node is marked as bound but there is no previous frame to reference")
+		}
+
 		// Left node was already materialized in the previous frame. Promote that frame and join only the terminal node here.
 		//
 		// prevFrame is the join root so LeftNodeConstraints can safely reference it in the edge ON clause without partitioning.
@@ -269,6 +273,10 @@ func (s *Translator) buildTraversalPatternRoot(partFrame *Frame, traversalStep *
 	)
 
 	if traversalStep.LeftNodeBound {
+		if partFrame.Previous == nil {
+			return pgsql.Query{}, fmt.Errorf("left node is marked as bound but there is no previous frame to reference")
+		}
+
 		// prevFrame is the JOIN root here (not comma-connected), so LeftNodeConstraints
 		// can safely reference it. No partitioning needed for this branch.
 		nextSelect.From = append(nextSelect.From, pgsql.FromClause{
@@ -295,6 +303,45 @@ func (s *Translator) buildTraversalPatternRoot(partFrame *Frame, traversalStep *
 				},
 			}},
 		})
+	} else if traversalStep.RightNodeBound && partFrame.Previous == nil {
+		// Self-referential pattern: the right node reuses the left node's variable (e.g. (u)-[]->(u)).
+		// There is no previous frame to promote as a FROM source. Join only the left node table and
+		// push the right-node join condition into WHERE so that start_id and end_id both reference
+		// the same node.
+		leftJoinLocal, leftJoinExternal := partitionConstraintByLocality(
+			traversalStep.LeftNodeConstraints,
+			pgsql.AsIdentifierSet(traversalStep.LeftNode.Identifier, traversalStep.Edge.Identifier),
+		)
+
+		if previousFrame, hasPrevious := s.previousValidFrame(traversalStep.Frame); hasPrevious {
+			nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+				Source: pgsql.TableReference{
+					Name: pgsql.CompoundIdentifier{previousFrame.Binding.Identifier},
+				},
+			})
+		}
+
+		nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+				Binding: models.OptionalValue(traversalStep.Edge.Identifier),
+			},
+			Joins: []pgsql.Join{{
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.OptionalValue(traversalStep.LeftNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: pgsql.OptionalAnd(leftJoinLocal, traversalStep.LeftNodeJoinCondition),
+				},
+			}},
+		})
+
+		// The right node's join condition (e.g. n0.id = e0.end_id) goes to WHERE since
+		// both endpoints reference the same node binding.
+		nextSelect.Where = pgsql.OptionalAnd(traversalStep.RightNodeJoinCondition, nextSelect.Where)
+		nextSelect.Where = pgsql.OptionalAnd(leftJoinExternal, nextSelect.Where)
 	} else if traversalStep.RightNodeBound {
 		// Right node was already materialized in a previous frame.
 		//


### PR DESCRIPTION
## Description

Fix a nil pointer dereference panic triggered by self-referential Cypher patterns such as `match p = (u)-[]->(u) return p`, where the same variable appears on both sides of a relationship.

The root cause was in `OptimizePatternConstraintBalance`: when `RightNodeBound` was true (because the right node reuses the left node's variable), the optimizer unconditionally flipped the traversal direction, setting `LeftNodeBound = true`. Downstream, `buildTraversalPatternRoot` dereferenced `Frame.Previous` — which is nil for a root traversal step with no preceding CTE — causing the panic.

**Changes:**
- **`constraints.go`**: Guard the flip in `OptimizePatternConstraintBalance` so it only occurs when a previous frame exists (`hasPreviousFrameBinding()`).
- **`traversal.go`**: Add a dedicated `RightNodeBound && Previous == nil` branch in `buildTraversalPatternRoot` that handles self-referential patterns by joining a single node table and pushing the right-node join condition to WHERE. Also add defensive nil checks on `Previous` in the `LeftNodeBound` and `RightNodeBound` branches to return clear errors instead of panics.
- **`expansion.go`**: Add a defensive nil check on `Previous` in `buildExpansionPatternRoot`'s `LeftNodeBound` branch, which has the same vulnerability pattern.
- **`predicate_test.go`**: Add `TestSelfReferentialPatternDoesNotPanic` covering directed, undirected, and variable-length expansion self-referential patterns.

Resolves: BED-8245

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

N/A

## Driver Impact

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when translating self-referential graph patterns where nodes reference themselves.
  * Improved error handling and validation for bound node references in traversal patterns.
  * Enhanced SQL construction for edge cases involving pattern binding.

* **Tests**
  * Added tests for self-referential pattern scenarios including directed/undirected variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/DAWGS/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->