### PR TITLE
feat: Add graph.StorageMaintainer interface - BED-8353

### DIFF
--- a/drivers/pg/driver.go
+++ b/drivers/pg/driver.go
@@ -177,7 +177,7 @@ func (s *Driver) RefreshKinds(ctx context.Context) error {
 	return s.SchemaManager.Fetch(ctx)
 }
 
-func (s *Driver) Optimize(ctx context.Context, opts ...graph.OptimizeOption) error {
+func (s *Driver) OptimizeStorage(ctx context.Context, opts ...graph.OptimizeOption) error {
 	config := &graph.OptimizeConfig{}
 	for _, opt := range opts {
 		opt(config)

--- a/drivers/pg/driver.go
+++ b/drivers/pg/driver.go
@@ -176,3 +176,13 @@ func (s *Driver) RefreshKinds(ctx context.Context) error {
 	s.SchemaManager.kindIDsByKind = map[int16]graph.Kind{}
 	return s.SchemaManager.Fetch(ctx)
 }
+
+func (s *Driver) Optimize(ctx context.Context, opts ...graph.OptimizeOption) error {
+	config := &graph.OptimizeConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// PostgreSQL VACUUM/ANALYZE implementation
+	return nil
+}

--- a/graph/optimize.go
+++ b/graph/optimize.go
@@ -1,0 +1,45 @@
+package graph
+
+import (
+	"context"
+)
+
+// TargetStorage identifies a region of graph storage that an
+// optimization pass may target.
+type TargetStorage int
+
+const (
+	Nodes TargetStorage = iota
+	Relationships
+)
+
+// OptimizeConfig is the resolved configuration for a single Optimize call.
+// Drivers consume this struct after all OptimizeOption values have been
+// applied. Options unsupported by a given driver should be ignored.
+type OptimizeConfig struct {
+	// Targets is the set of storage regions to optimize. An empty slice means
+	// "all regions the driver knows about".
+	Targets []TargetStorage
+}
+
+// OptimizeOption mutates an OptimizeConfig.
+type OptimizeOption func(*OptimizeConfig)
+
+// OptimizeTargets restricts the optimization pass to the given storage regions.
+func OptimizeTargets(targets ...TargetStorage) OptimizeOption {
+	return func(c *OptimizeConfig) {
+		c.Targets = append(c.Targets, targets...)
+	}
+}
+
+// StorageMaintainer is an optional capability implemented by drivers that can
+// perform storage maintenance. Consumers should detect support with a
+// type assertion against a graph.Database:
+//
+//	if m, ok := db.(graph.StorageMaintainer); ok {
+//	    err := m.Optimize(ctx, graph.OptimizeTargets(graph.Nodes, graph.Relationships))
+//	    ...
+//	}
+type StorageMaintainer interface {
+	Optimize(ctx context.Context, opts ...OptimizeOption) error
+}

--- a/graph/optimize.go
+++ b/graph/optimize.go
@@ -36,22 +36,22 @@ func OptimizeTargets(targets ...TargetStorage) OptimizeOption {
 	}
 }
 
-// StorageMaintainer is an optional capability implemented by drivers that
-// can perform storage maintenance. Drivers that cannot perform meaningful maintenance
+// StorageOptimizer is an optional capability implemented by drivers that
+// can perform storage optimization. Drivers that cannot perform meaningful optimization
 // must not implement this interface; a failed type assertion is the
-// signal for "this driver does not support storage maintenance".
+// signal for "this driver does not support storage optimization".
 // A non-nil error returned from Optimize signals a driver-specific failure
 // during a supported call.
 //
 // Consumers detect support with a type assertion against a graph.Database:
 //
-//	if m, ok := db.(graph.StorageMaintainer); ok {
+//	if m, ok := db.(graph.StorageOptimizer); ok {
 //	    err := m.Optimize(ctx, graph.OptimizeTargets(graph.Nodes, graph.Relationships))
 //	    ...
 //	}
-type StorageMaintainer interface {
-	// Optimize runs a storage maintenance pass against the regions
+type StorageOptimizer interface {
+	// OptimizeStorage runs a storage optimization pass against the regions
 	// identified by opts. With no options, every region the driver
 	// recognizes is optimized.
-	Optimize(ctx context.Context, opts ...OptimizeOption) error
+	OptimizeStorage(ctx context.Context, opts ...OptimizeOption) error
 }

--- a/graph/optimize.go
+++ b/graph/optimize.go
@@ -13,7 +13,7 @@ const (
 	Relationships
 )
 
-// OptimizeConfig is the resolved configuration for a single Optimize call.
+// OptimizeConfig is the resolved configuration for a single OptimizeStorage call.
 // Drivers apply every OptimizeOption to this struct before reading it.
 type OptimizeConfig struct {
 	// Targets is the set of storage regions to optimize. A nil or empty
@@ -28,7 +28,7 @@ type OptimizeOption func(*OptimizeConfig)
 // OptimizeTargets restricts the optimization pass to the given storage
 // regions. Repeated calls append targets rather than replacing them.
 // Calling OptimizeTargets with no arguments does not change the resolved
-// target set; if no targets are configured by the time Optimize runs, the
+// target set; if no targets are configured by the time OptimizeStorage runs, the
 // driver treats that as "all regions it knows about".
 func OptimizeTargets(targets ...TargetStorage) OptimizeOption {
 	return func(c *OptimizeConfig) {
@@ -40,7 +40,7 @@ func OptimizeTargets(targets ...TargetStorage) OptimizeOption {
 // can perform storage optimization. Drivers that cannot perform meaningful optimization
 // must not implement this interface; a failed type assertion is the
 // signal for "this driver does not support storage optimization".
-// A non-nil error returned from Optimize signals a driver-specific failure
+// A non-nil error returned from OptimizeStorage signals a driver-specific failure
 // during a supported call.
 //
 // Consumers detect support with a type assertion against a graph.Database:

--- a/graph/optimize.go
+++ b/graph/optimize.go
@@ -4,8 +4,8 @@ import (
 	"context"
 )
 
-// TargetStorage identifies a region of graph storage that an
-// optimization pass may target.
+// TargetStorage identifies a region of graph storage that an optimization
+// pass may target.
 type TargetStorage int
 
 const (
@@ -14,32 +14,44 @@ const (
 )
 
 // OptimizeConfig is the resolved configuration for a single Optimize call.
-// Drivers consume this struct after all OptimizeOption values have been
-// applied. Options unsupported by a given driver should be ignored.
+// Drivers apply every OptimizeOption to this struct before reading it.
 type OptimizeConfig struct {
-	// Targets is the set of storage regions to optimize. An empty slice means
-	// "all regions the driver knows about".
+	// Targets is the set of storage regions to optimize. A nil or empty
+	// slice instructs the driver to optimize every region it knows about.
 	Targets []TargetStorage
 }
 
-// OptimizeOption mutates an OptimizeConfig.
+// OptimizeOption mutates an OptimizeConfig and is applied in the order
+// passed to Optimize.
 type OptimizeOption func(*OptimizeConfig)
 
-// OptimizeTargets restricts the optimization pass to the given storage regions.
+// OptimizeTargets restricts the optimization pass to the given storage
+// regions. Repeated calls append targets rather than replacing them.
+// Calling OptimizeTargets with no arguments does not change the resolved
+// target set; if no targets are configured by the time Optimize runs, the
+// driver treats that as "all regions it knows about".
 func OptimizeTargets(targets ...TargetStorage) OptimizeOption {
 	return func(c *OptimizeConfig) {
 		c.Targets = append(c.Targets, targets...)
 	}
 }
 
-// StorageMaintainer is an optional capability implemented by drivers that can
-// perform storage maintenance. Consumers should detect support with a
-// type assertion against a graph.Database:
+// StorageMaintainer is an optional capability implemented by drivers that
+// can perform storage maintenance. Drivers that cannot perform meaningful maintenance
+// must not implement this interface; a failed type assertion is the
+// signal for "this driver does not support storage maintenance".
+// A non-nil error returned from Optimize signals a driver-specific failure
+// during a supported call.
+//
+// Consumers detect support with a type assertion against a graph.Database:
 //
 //	if m, ok := db.(graph.StorageMaintainer); ok {
 //	    err := m.Optimize(ctx, graph.OptimizeTargets(graph.Nodes, graph.Relationships))
 //	    ...
 //	}
 type StorageMaintainer interface {
+	// Optimize runs a storage maintenance pass against the regions
+	// identified by opts. With no options, every region the driver
+	// recognizes is optimized.
 	Optimize(ctx context.Context, opts ...OptimizeOption) error
 }

--- a/graph/optimize_test.go
+++ b/graph/optimize_test.go
@@ -1,0 +1,54 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptimizeOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts []graph.OptimizeOption
+		want []graph.TargetStorage
+	}{
+		{
+			name: "no options yields nil Targets",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "OptimizeTargets with no args leaves Targets nil",
+			opts: []graph.OptimizeOption{graph.OptimizeTargets()},
+			want: nil,
+		},
+		{
+			name: "single call preserves order",
+			opts: []graph.OptimizeOption{graph.OptimizeTargets(graph.Nodes, graph.Relationships)},
+			want: []graph.TargetStorage{graph.Nodes, graph.Relationships},
+		},
+		{
+			name: "repeated calls accumulate",
+			opts: []graph.OptimizeOption{
+				graph.OptimizeTargets(graph.Nodes),
+				graph.OptimizeTargets(graph.Relationships),
+			},
+			want: []graph.TargetStorage{graph.Nodes, graph.Relationships},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg graph.OptimizeConfig
+			for _, o := range tc.opts {
+				o(&cfg)
+			}
+			assert.Equal(t, tc.want, cfg.Targets)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Resolves: BED-8353
- This change breaks out a piece of this PR https://github.com/SpecterOps/DAWGS/pull/79
- It defines a new optional interface that dawgs drivers can implement for optimizing storage via methods like vacuum, analyze, etc. Extensive Godoc strings added with help from Mr. Auggie
- The OptimizeOption functional option pattern provides extensibility for future optimization parameters beyond just storage targets. This is the only difference between this interface proposal and the original implementation proposed in the draft PoC. 

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [ ] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced storage optimization API for graph databases, enabling selective optimization of storage components.
  * PostgreSQL driver now supports the optimization interface.

* **Tests**
  * Added tests validating optimization configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->