### PR TITLE
chore: Bump test fixtures to use PG18 - BED-8581

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_USER: dawgs
           POSTGRES_PASSWORD: weneedbetterpasswords

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.iml
+.DS_Store
 
 # User IDE Files
 .idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     environment:
       POSTGRES_USER: dawgs
       POSTGRES_PASSWORD: weneedbetterpasswords
@@ -8,7 +8,7 @@ services:
     ports:
       - "65432:5432"
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql
 
   neo4j:
     image: neo4j:4.4.42


### PR DESCRIPTION
## Description

Updates test fixtures to utilize PG18 alongside the fleet.

Resolves: BED-8581

## Type of Change

- [X] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [X] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [X] Code is formatted
- [X] All existing tests pass
- [X] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded PostgreSQL from version 16 to 18 across testing and development environments
  * Updated development configuration to ignore macOS system files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->