### PR TITLE
feat: OptimizeStorage method stub - BED-8353

### DIFF
--- a/drivers/neo4j/driver.go
+++ b/drivers/neo4j/driver.go
@@ -192,3 +192,7 @@ func (s *driver) RefreshKinds(_ context.Context) error {
 	// This isn't needed for neo4j
 	return nil
 }
+
+func (s *driver) OptimizeStorage(ctx context.Context) error {
+	return nil
+}

--- a/drivers/pg/driver.go
+++ b/drivers/pg/driver.go
@@ -176,3 +176,7 @@ func (s *Driver) RefreshKinds(ctx context.Context) error {
 	s.SchemaManager.kindIDsByKind = map[int16]graph.Kind{}
 	return s.SchemaManager.Fetch(ctx)
 }
+
+func (s *Driver) OptimizeStorage(ctx context.Context) error {
+	return nil
+}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -420,4 +420,7 @@ type Database interface {
 
 	// RefreshKinds refreshes the in memory kinds maps
 	RefreshKinds(ctx context.Context) error
+
+	// OptimizeStorage performs routine maintenance operations on the underlying storage
+	OptimizeStorage(ctx context.Context) error
 }

--- a/graph/switch.go
+++ b/graph/switch.go
@@ -228,6 +228,6 @@ func (s *DatabaseSwitch) OptimizeStorage(ctx context.Context) error {
 		s.currentDBLock.RLock()
 		defer s.currentDBLock.RUnlock()
 
-		return s.currentDB.OptimizeStorage(ctx)
+		return s.currentDB.OptimizeStorage(internalCtx)
 	}
 }

--- a/graph/switch.go
+++ b/graph/switch.go
@@ -218,3 +218,16 @@ func (s *DatabaseSwitch) RefreshKinds(ctx context.Context) error {
 		return s.currentDB.RefreshKinds(ctx)
 	}
 }
+
+func (s *DatabaseSwitch) OptimizeStorage(ctx context.Context) error {
+	if internalCtx, err := s.newInternalContext(ctx); err != nil {
+		return err
+	} else {
+		defer s.retireInternalContext(internalCtx)
+
+		s.currentDBLock.RLock()
+		defer s.currentDBLock.RUnlock()
+
+		return s.currentDB.OptimizeStorage(ctx)
+	}
+}

--- a/tools/dawgrun/pkg/commands/config_test.go
+++ b/tools/dawgrun/pkg/commands/config_test.go
@@ -56,6 +56,10 @@ func (s *fakeDatabase) RefreshKinds(context.Context) error {
 	return nil
 }
 
+func (s *fakeDatabase) OptimizeStorage(ctx context.Context) error {
+	return nil
+}
+
 func TestConfigRoundTrip(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	expected := types.Config{


### PR DESCRIPTION
## Description
This PR adds a method to the `graph.Database` interface named `OptimizeStorage`. The PG and neo drivers implement a stub for this method that only returns nil. 

Follow up tickets will implement some PG functionality.

Resolves: BED-8353

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [ ] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented storage optimization functionality that allows the system to trigger routine maintenance operations on the underlying database infrastructure. This new enhancement supports performance improvements and helps manage storage efficiency more effectively. The optimization capability is now available across all supported database backends, enabling more efficient resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->