### PR TITLE
feat: change retriever output to jsonl

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ comparison mode yet. The command can emit JSONL records plus Markdown and JSON s
 against a previous JSONL baseline.
 
 `go run ./cmd/retriever` dumps and loads live Dawgs graph databases as
-manifest-based collections of compact OpenGraph-derived fragments. It supports
+manifest-based collections of compressed JSONL fragments. It supports
 PostgreSQL and Neo4j, gzip and zstd compression, checksum validation before
 load, optional deterministic property scrubbing, and a read-throughput benchmark
 mode. It can also package dumps as single HPKE/ML-KEM encrypted TAR archives.

--- a/cmd/retriever/README.md
+++ b/cmd/retriever/README.md
@@ -13,7 +13,7 @@ relationship fragments contain one JSON object per line and use paths such as
 `graphs/default/edges-000001.jsonl.zst`. The manifest identifies each file's
 phase, record count, compressed and uncompressed sizes, and SHA-256 checksum.
 The writer always terminates records with a newline; the loader also accepts a
-final record without one.
+final record without one. The loader rejects JSONL lines larger than 10 MiB.
 
 ## Dump
 

--- a/cmd/retriever/README.md
+++ b/cmd/retriever/README.md
@@ -101,7 +101,10 @@ Existing non-empty unpack output directories are refused unless `-force` is
 supplied. Unpacked collections retain the normal `manifest.json` and fragment
 layout and can be loaded with `retriever load -in ./dumpdir`. Before promoting
 the staged output directory, unpack validates the manifest, expected paths,
-compressed sizes and checksums, JSONL records, source IDs, and record counts.
+compressed sizes and checksums, and the absence of unexpected files. Unpack does
+not decompress fragments or validate JSONL records, source IDs, or record
+counts; that semantic validation occurs when the collection is passed to
+`retriever load`.
 
 ## Scrubbed Dumps
 
@@ -144,8 +147,10 @@ Load reads and validates `manifest.json`, then verifies every fragment checksum,
 JSONL record, and record count before performing database writes. It asserts
 destination graph schemas from the manifest metadata and loads all nodes before
 relationships. Graph names from the dump are preserved; load does not support
-overriding graph names. Archive loads decrypt and validate into a temporary
-collection directory before opening the database.
+overriding graph names. Direct archive loads decrypt and perform integrity-only
+unpack validation in a temporary collection directory, then run the same
+semantic preflight as directory loads before schema assertion or database
+writes.
 
 The preflight combines compressed byte counting and SHA-256 calculation with
 JSONL decoding in one read of each fragment. Load then reopens and decodes the

--- a/cmd/retriever/README.md
+++ b/cmd/retriever/README.md
@@ -1,11 +1,19 @@
 # retriever
 
 `retriever` dumps and loads live Dawgs graph databases as manifest-based
-collections of compact OpenGraph-derived JSON fragments.
+collections of compact JSONL fragments.
 
 The v1 collection format is intended for idle databases. Dumps are deterministic
 by entity ID order and cap each graph scan at the entity counts observed when
 counting starts, but they do not provide a transactional cross-fragment snapshot.
+
+The collection manifest format is `retriever-jsonl-collection-v1`. Node and
+relationship fragments contain one JSON object per line and use paths such as
+`graphs/default/nodes-000001.jsonl.zst` and
+`graphs/default/edges-000001.jsonl.zst`. The manifest identifies each file's
+phase, record count, compressed and uncompressed sizes, and SHA-256 checksum.
+The writer always terminates records with a newline; the loader also accepts a
+final record without one.
 
 ## Dump
 
@@ -91,7 +99,9 @@ retriever unpack \
 
 Existing non-empty unpack output directories are refused unless `-force` is
 supplied. Unpacked collections retain the normal `manifest.json` and fragment
-layout and can be loaded with `retriever load -in ./dumpdir`.
+layout and can be loaded with `retriever load -in ./dumpdir`. Before promoting
+the staged output directory, unpack validates the manifest, expected paths,
+compressed sizes and checksums, JSONL records, source IDs, and record counts.
 
 ## Scrubbed Dumps
 
@@ -130,11 +140,22 @@ retriever load \
   -identity ./retriever-private.key
 ```
 
-Load reads and validates `manifest.json`, verifies every fragment checksum in a
-separate pass, asserts destination graph schemas from the manifest metadata, and
-then loads all nodes before relationships. Graph names from the dump are
-preserved; load does not support overriding graph names. Archive loads decrypt
-and validate into a temporary collection directory before opening the database.
+Load reads and validates `manifest.json`, then verifies every fragment checksum,
+JSONL record, and record count before performing database writes. It asserts
+destination graph schemas from the manifest metadata and loads all nodes before
+relationships. Graph names from the dump are preserved; load does not support
+overriding graph names. Archive loads decrypt and validate into a temporary
+collection directory before opening the database.
+
+The preflight combines compressed byte counting and SHA-256 calculation with
+JSONL decoding in one read of each fragment. Load then reopens and decodes the
+fragments while writing to the database. This intentional second decode ensures
+that every fragment is semantically valid before any database mutation. Measure
+the complete preflight-plus-decode fragment path with:
+
+```bash
+go test ./retriever -run '^$' -bench '^BenchmarkLoadFragmentPath$' -benchmem
+```
 
 Load refuses to write into target graphs that already contain nodes or
 relationships; clear the destination graph before restoring a collection.
@@ -211,6 +232,7 @@ completion. Text or JSON benchmark reports remain on stdout.
 Unit tests focus on collection format validation, compression/checksum behavior,
 scrub transformations, schema planning, edge resolution, CLI flag validation,
 and other pure helpers. Full database dump/load behavior is covered by
-integration tests rather than heavy mocks of Dawgs database interfaces. This
-keeps tests focused on durable behavior instead of line coverage for
-orchestration code.
+integration tests for the backend selected by `CONNECTION_STRING`. The round-trip
+case crosses scan-batch and shard boundaries and verifies restored properties and
+topology. `BenchmarkLoadFragmentPath` measures preflight plus the second fragment
+decode used during database loading.

--- a/cmd/retriever/bench.go
+++ b/cmd/retriever/bench.go
@@ -465,7 +465,7 @@ func benchEdges(ctx context.Context, db graph.Database, targetGraph graph.Graph,
 }
 
 func benchNodeBatch(nodes []*graph.Node, options benchOptions) (benchPhaseResult, error) {
-	return benchCompressedBatch(len(nodes), options, func() retriever.NodeFragment {
+	return benchCompressedBatch(len(nodes), options, func() []retriever.FragmentNode {
 		items := make([]retriever.FragmentNode, 0, len(nodes))
 		for _, node := range nodes {
 			kinds := node.Kinds.Strings()
@@ -478,15 +478,12 @@ func benchNodeBatch(nodes []*graph.Node, options benchOptions) (benchPhaseResult
 			})
 		}
 
-		return retriever.NodeFragment{
-			Phase: retriever.PhaseNodes,
-			Items: items,
-		}
+		return items
 	})
 }
 
 func benchRelationshipBatch(relationships []*graph.Relationship, options benchOptions) (benchPhaseResult, error) {
-	return benchCompressedBatch(len(relationships), options, func() retriever.EdgeFragment {
+	return benchCompressedBatch(len(relationships), options, func() []retriever.FragmentEdge {
 		items := make([]retriever.FragmentEdge, 0, len(relationships))
 		for _, relationship := range relationships {
 			kind := ""
@@ -502,14 +499,11 @@ func benchRelationshipBatch(relationships []*graph.Relationship, options benchOp
 			})
 		}
 
-		return retriever.EdgeFragment{
-			Phase: retriever.PhaseEdges,
-			Items: items,
-		}
+		return items
 	})
 }
 
-func benchCompressedBatch[T any](count int, options benchOptions, buildPayload func() T) (benchPhaseResult, error) {
+func benchCompressedBatch[T any](count int, options benchOptions, buildRecords func() []T) (benchPhaseResult, error) {
 	result := benchPhaseResult{
 		Count: int64(count),
 	}
@@ -518,7 +512,7 @@ func benchCompressedBatch[T any](count int, options benchOptions, buildPayload f
 	}
 
 	encodeStarted := time.Now()
-	uncompressedBytes, compressedBytes, err := retriever.CompressedJSONSize(options.Compression, options.ZstdLevel, buildPayload())
+	uncompressedBytes, compressedBytes, err := retriever.CompressedJSONLinesSize(options.Compression, options.ZstdLevel, buildRecords())
 	result.EncodeCompressTime = time.Since(encodeStarted)
 
 	if err != nil {

--- a/cmd/retriever/retriever_integration_test.go
+++ b/cmd/retriever/retriever_integration_test.go
@@ -27,12 +27,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/specterops/dawgs/drivers/neo4j"
 	"github.com/specterops/dawgs/drivers/pg"
 	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/ops"
 	"github.com/specterops/dawgs/retriever"
 )
 
-func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
+func TestDumpLoadRoundTrip(t *testing.T) {
 	connection := os.Getenv("CONNECTION_STRING")
 	if connection == "" {
 		t.Skip("CONNECTION_STRING not set")
@@ -41,8 +43,10 @@ func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("infer driver: %v", err)
 	}
-	if driverName != pg.DriverName {
-		t.Skipf("CONNECTION_STRING selects %s, not PostgreSQL", driverName)
+	switch driverName {
+	case pg.DriverName, neo4j.DriverName:
+	default:
+		t.Skipf("CONNECTION_STRING selects unsupported retriever integration driver %s", driverName)
 	}
 
 	ctx := context.Background()
@@ -69,28 +73,57 @@ func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("assert schema: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+	clearGraph := func() error {
+		return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
 			return tx.WithGraph(graph.Graph{
 				Name: graphName,
 			}).Nodes().Delete()
 		})
+	}
+	if err := clearGraph(); err != nil {
+		t.Fatalf("clear graph before seed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = clearGraph()
 	})
 
+	const (
+		nodeCount = 7
+		edgeCount = 5
+		batchSize = 2
+		shardSize = 3
+	)
 	if err := db.WriteTransaction(ctx, func(tx graph.Transaction) error {
 		tx = tx.WithGraph(graph.Graph{
 			Name: graphName,
 		})
-		alice, err := tx.CreateNode(graph.AsProperties(map[string]any{"name": "alice"}), userKind)
-		if err != nil {
-			return err
+
+		nodes := make([]*graph.Node, 0, nodeCount)
+		for index := range nodeCount {
+			kind := userKind
+			if index%2 == 1 {
+				kind = systemKind
+			}
+
+			node, err := tx.CreateNode(graph.AsProperties(map[string]any{
+				"name": fmt.Sprintf("node-%d", index),
+				"role": fmt.Sprintf("role-%d", index%3),
+			}), kind)
+			if err != nil {
+				return err
+			}
+			nodes = append(nodes, node)
 		}
-		system, err := tx.CreateNode(graph.AsProperties(map[string]any{"name": "server"}), systemKind)
-		if err != nil {
-			return err
+
+		for index := range edgeCount {
+			if _, err := tx.CreateRelationshipByIDs(nodes[index].ID, nodes[index+1].ID, adminKind, graph.AsProperties(map[string]any{
+				"route": fmt.Sprintf("route-%d", index),
+			})); err != nil {
+				return err
+			}
 		}
-		_, err = tx.CreateRelationshipByIDs(alice.ID, system.ID, adminKind, graph.AsProperties(map[string]any{"source": "test"}))
-		return err
+
+		return nil
 	}); err != nil {
 		t.Fatalf("seed graph: %v", err)
 	}
@@ -101,8 +134,8 @@ func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count graph entities: %v", err)
 	}
-	if entitySnapshot.NodeCount != 2 || entitySnapshot.EdgeCount != 1 {
-		t.Skipf("graph target %q is not isolated by the current PostgreSQL query path: nodes=%d edges=%d", graphName, entitySnapshot.NodeCount, entitySnapshot.EdgeCount)
+	if entitySnapshot.NodeCount != nodeCount || entitySnapshot.EdgeCount != edgeCount {
+		t.Fatalf("unexpected seeded graph counts: nodes=%d edges=%d", entitySnapshot.NodeCount, entitySnapshot.EdgeCount)
 	}
 
 	dumpDir := t.TempDir()
@@ -113,14 +146,36 @@ func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
 		Scrub:       retriever.ScrubNone,
 		Compression: retriever.CompressionGzip,
 		ZstdLevel:   retriever.DefaultZstdLevel,
-		ShardSize:   1,
-		BatchSize:   1,
+		ShardSize:   shardSize,
+		BatchSize:   batchSize,
 	})
 	if err != nil {
 		t.Fatalf("dump: %v", err)
 	}
-	if dumpResult.NodeCount != 2 || dumpResult.EdgeCount != 1 {
+	if dumpResult.NodeCount != nodeCount || dumpResult.EdgeCount != edgeCount {
 		t.Fatalf("unexpected dump counts: nodes=%d edges=%d", dumpResult.NodeCount, dumpResult.EdgeCount)
+	}
+	if got := len(dumpResult.Manifest.Graphs); got != 1 {
+		t.Fatalf("dump manifest graph count = %d", got)
+	}
+	graphEntry := dumpResult.Manifest.Graphs[0]
+	if graphEntry.NodeCount != nodeCount || graphEntry.EdgeCount != edgeCount {
+		t.Fatalf("unexpected manifest graph counts: nodes=%d edges=%d", graphEntry.NodeCount, graphEntry.EdgeCount)
+	}
+	var nodeFiles, edgeFiles int
+	for _, fileEntry := range graphEntry.Files {
+		switch fileEntry.Phase {
+		case retriever.PhaseNodes:
+			nodeFiles++
+		case retriever.PhaseEdges:
+			edgeFiles++
+		}
+		if fileEntry.Count > shardSize {
+			t.Fatalf("fragment %s count %d exceeds shard size %d", fileEntry.Path, fileEntry.Count, shardSize)
+		}
+	}
+	if nodeFiles != 3 || edgeFiles != 2 {
+		t.Fatalf("unexpected manifest shards: node files=%d edge files=%d", nodeFiles, edgeFiles)
 	}
 	if dumpResult.Manifest.Metrics == nil {
 		t.Fatalf("dump manifest is missing metrics")
@@ -128,46 +183,107 @@ func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
 	if got := len(dumpResult.Manifest.Metrics.Graphs); got != 1 {
 		t.Fatalf("dump metrics graph count = %d", got)
 	}
-	if dumpResult.Manifest.Metrics.Graphs[0].NodeCount != 2 || dumpResult.Manifest.Metrics.Graphs[0].EdgeCount != 1 {
+	if dumpResult.Manifest.Metrics.Graphs[0].NodeCount != nodeCount || dumpResult.Manifest.Metrics.Graphs[0].EdgeCount != edgeCount {
 		t.Fatalf("unexpected dump metrics counts: %+v", dumpResult.Manifest.Metrics.Graphs[0])
 	}
 
 	if _, err := retriever.Load(ctx, db, driverName, retriever.LoadOptions{
 		InputDir:      dumpDir,
-		BatchSize:     1,
+		BatchSize:     batchSize,
 		VerifyMetrics: true,
 	}); err == nil || !strings.Contains(err.Error(), "is not empty") {
 		t.Fatalf("expected non-empty target load error, got %v", err)
 	}
 
-	if err := db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-		return tx.WithGraph(graph.Graph{
-			Name: graphName,
-		}).Nodes().Delete()
-	}); err != nil {
+	if err := clearGraph(); err != nil {
 		t.Fatalf("clear graph before load: %v", err)
 	}
 
 	loadResult, err := retriever.Load(ctx, db, driverName, retriever.LoadOptions{
 		InputDir:      dumpDir,
-		BatchSize:     1,
+		BatchSize:     batchSize,
 		VerifyMetrics: true,
 	})
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if loadResult.NodeCount != 2 || loadResult.EdgeCount != 1 {
+	if loadResult.NodeCount != nodeCount || loadResult.EdgeCount != edgeCount {
 		t.Fatalf("unexpected load counts: nodes=%d edges=%d", loadResult.NodeCount, loadResult.EdgeCount)
+	}
+
+	var loadedNodes []*graph.Node
+	var loadedEdges []*graph.Relationship
+	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		tx = tx.WithGraph(graph.Graph{Name: graphName})
+		var err error
+		if loadedNodes, err = ops.FetchNodes(tx.Nodes()); err != nil {
+			return err
+		}
+		loadedEdges, err = ops.FetchRelationships(tx.Relationships())
+		return err
+	}); err != nil {
+		t.Fatalf("read restored topology: %v", err)
+	}
+	if len(loadedNodes) != nodeCount || len(loadedEdges) != edgeCount {
+		t.Fatalf("unexpected restored topology counts: nodes=%d edges=%d", len(loadedNodes), len(loadedEdges))
+	}
+
+	nodeNames := make(map[graph.ID]string, len(loadedNodes))
+	expectedRoles := make(map[string]string, nodeCount)
+	expectedKinds := make(map[string]string, nodeCount)
+	for index := range nodeCount {
+		name := fmt.Sprintf("node-%d", index)
+		expectedRoles[name] = fmt.Sprintf("role-%d", index%3)
+		expectedKinds[name] = userKind.String()
+		if index%2 == 1 {
+			expectedKinds[name] = systemKind.String()
+		}
+	}
+	for _, node := range loadedNodes {
+		if node.Properties == nil {
+			t.Fatalf("restored node %d is missing properties", node.ID)
+		}
+		name := fmt.Sprint(node.Properties.Get("name").Any())
+		role := fmt.Sprint(node.Properties.Get("role").Any())
+		nodeNames[node.ID] = name
+		if expectedRole, ok := expectedRoles[name]; !ok || role != expectedRole {
+			t.Fatalf("unexpected restored node properties: %+v", node.Properties.MapOrEmpty())
+		}
+		if len(node.Kinds) != 1 || node.Kinds[0].String() != expectedKinds[name] {
+			t.Fatalf("unexpected restored node kinds for %s: %v", name, node.Kinds.Strings())
+		}
+	}
+
+	restoredRoutes := map[string]string{}
+	for _, relationship := range loadedEdges {
+		startName, startOK := nodeNames[relationship.StartID]
+		endName, endOK := nodeNames[relationship.EndID]
+		if !startOK || !endOK {
+			t.Fatalf("restored relationship has unresolved endpoint IDs: %+v", relationship)
+		}
+		if relationship.Kind == nil || relationship.Kind.String() != adminKind.String() {
+			t.Fatalf("unexpected restored relationship kind: %+v", relationship.Kind)
+		}
+		if relationship.Properties == nil {
+			t.Fatalf("restored relationship is missing properties: %+v", relationship)
+		}
+		restoredRoutes[startName+"->"+endName] = fmt.Sprint(relationship.Properties.Get("route").Any())
+	}
+	for index := range edgeCount {
+		path := fmt.Sprintf("node-%d->node-%d", index, index+1)
+		if route := restoredRoutes[path]; route != fmt.Sprintf("route-%d", index) {
+			t.Fatalf("restored route %s = %q", path, route)
+		}
 	}
 
 	verifyResult, err := retriever.Verify(ctx, db, driverName, retriever.VerifyOptions{
 		InputDir:  dumpDir,
-		BatchSize: 1,
+		BatchSize: batchSize,
 	})
 	if err != nil {
 		t.Fatalf("verify: %v", err)
 	}
-	if verifyResult.NodeCount != 2 || verifyResult.EdgeCount != 1 {
+	if verifyResult.NodeCount != nodeCount || verifyResult.EdgeCount != edgeCount {
 		t.Fatalf("unexpected verify counts: nodes=%d edges=%d", verifyResult.NodeCount, verifyResult.EdgeCount)
 	}
 
@@ -183,7 +299,7 @@ func TestPostgreSQLDumpLoadRoundTrip(t *testing.T) {
 
 	_, err = retriever.Verify(ctx, db, driverName, retriever.VerifyOptions{
 		InputDir:  dumpDir,
-		BatchSize: 1,
+		BatchSize: batchSize,
 	})
 	var mismatch retriever.MetricsMismatchError
 	if !errors.As(err, &mismatch) {

--- a/cmd/retriever/retriever_integration_test.go
+++ b/cmd/retriever/retriever_integration_test.go
@@ -43,9 +43,7 @@ func TestDumpLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("infer driver: %v", err)
 	}
-	switch driverName {
-	case pg.DriverName, neo4j.DriverName:
-	default:
+	if driverName != pg.DriverName:
 		t.Skipf("CONNECTION_STRING selects unsupported retriever integration driver %s", driverName)
 	}
 

--- a/cmd/retriever/retriever_integration_test.go
+++ b/cmd/retriever/retriever_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/specterops/dawgs/drivers/neo4j"
 	"github.com/specterops/dawgs/drivers/pg"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/ops"
@@ -43,7 +42,7 @@ func TestDumpLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("infer driver: %v", err)
 	}
-	if driverName != pg.DriverName:
+	if driverName != pg.DriverName {
 		t.Skipf("CONNECTION_STRING selects unsupported retriever integration driver %s", driverName)
 	}
 

--- a/retriever/archive_envelope.go
+++ b/retriever/archive_envelope.go
@@ -403,7 +403,7 @@ func validateUnpackedCollection(outputDir string) error {
 	if err != nil {
 		return err
 	}
-	if err := verifyManifestFiles(outputDir, nextManifest); err != nil {
+	if err := verifyCollectionFragments(outputDir, nextManifest); err != nil {
 		return err
 	}
 

--- a/retriever/archive_envelope.go
+++ b/retriever/archive_envelope.go
@@ -403,7 +403,7 @@ func validateUnpackedCollection(outputDir string) error {
 	if err != nil {
 		return err
 	}
-	if err := verifyCollectionFragments(outputDir, nextManifest); err != nil {
+	if err := verifyManifestFiles(outputDir, nextManifest); err != nil {
 		return err
 	}
 

--- a/retriever/archive_envelope_test.go
+++ b/retriever/archive_envelope_test.go
@@ -3,6 +3,7 @@ package retriever
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"crypto/hpke"
 	"crypto/sha256"
 	"encoding/binary"
@@ -13,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/specterops/dawgs/drivers/pg"
 )
 
 func TestEncryptedArchiveRoundTrip(t *testing.T) {
@@ -401,7 +404,7 @@ func TestEncryptedCollectionArchiveRejectsInvalidCollection(t *testing.T) {
 	}
 }
 
-func TestEncryptedCollectionArchiveRejectsMalformedJSONLines(t *testing.T) {
+func TestEncryptedCollectionArchiveAllowsSelfConsistentMalformedJSONLines(t *testing.T) {
 	privateKey, publicKey := generateTestArchiveKeyPair(t)
 	dumpDir := writeArchiveFixture(t)
 	value, err := readManifest(dumpDir)
@@ -437,12 +440,19 @@ func TestEncryptedCollectionArchiveRejectsMalformedJSONLines(t *testing.T) {
 		ArchiveIdentity: privateKey,
 		OutputDir:       outputDir,
 	})
-	if err == nil || !strings.Contains(err.Error(), "unknown field") {
-		t.Fatalf("expected malformed JSONL validation error, got %v", err)
+	if err != nil {
+		t.Fatalf("unpack integrity-valid malformed JSONL collection: %v", err)
 	}
 
-	if _, err := os.Stat(outputDir); !os.IsNotExist(err) {
-		t.Fatalf("malformed collection was promoted to output dir: %v", err)
+	if originalTree, unpackedTree := readFileTree(t, dumpDir), readFileTree(t, outputDir); !equalFileTrees(originalTree, unpackedTree) {
+		t.Fatalf("unpacked malformed collection does not match original")
+	}
+
+	loadOptions := DefaultLoadOptions("")
+	loadOptions.ArchiveReader = bytes.NewReader(archive.Bytes())
+	loadOptions.ArchiveIdentity = privateKey
+	if _, err := Load(context.Background(), nil, pg.DriverName, loadOptions); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected direct archive load semantic preflight error, got %v", err)
 	}
 }
 

--- a/retriever/archive_envelope_test.go
+++ b/retriever/archive_envelope_test.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"crypto/hpke"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"io"
 	"os"
@@ -396,6 +398,51 @@ func TestEncryptedCollectionArchiveRejectsInvalidCollection(t *testing.T) {
 
 	if _, err := os.Stat(outputDir); !os.IsNotExist(err) {
 		t.Fatalf("invalid collection was promoted to output dir: %v", err)
+	}
+}
+
+func TestEncryptedCollectionArchiveRejectsMalformedJSONLines(t *testing.T) {
+	privateKey, publicKey := generateTestArchiveKeyPair(t)
+	dumpDir := writeArchiveFixture(t)
+	value, err := readManifest(dumpDir)
+	if err != nil {
+		t.Fatalf("read fixture manifest: %v", err)
+	}
+
+	nodeEntry := &value.Graphs[0].Files[0]
+	payload := "{\"id\":\"1\",\"kinds\":[\"User\"],\"unexpected\":true}\n"
+	fragmentPath := filepath.Join(dumpDir, filepath.FromSlash(nodeEntry.Path))
+	writeCompressedPayload(t, fragmentPath, value.Compression, payload)
+
+	contents, err := os.ReadFile(fragmentPath)
+	if err != nil {
+		t.Fatalf("read malformed fragment: %v", err)
+	}
+	checksum := sha256.Sum256(contents)
+	nodeEntry.CompressedBytes = int64(len(contents))
+	nodeEntry.UncompressedBytes = int64(len(payload))
+	nodeEntry.SHA256 = hex.EncodeToString(checksum[:])
+	if err := writeManifest(dumpDir, value); err != nil {
+		t.Fatalf("write self-consistent malformed collection manifest: %v", err)
+	}
+
+	var archive bytes.Buffer
+	if err := WriteEncryptedCollectionArchive(&archive, dumpDir, publicKey); err != nil {
+		t.Fatalf("write malformed collection archive: %v", err)
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "out")
+	err = Unpack(UnpackOptions{
+		ArchiveReader:   bytes.NewReader(archive.Bytes()),
+		ArchiveIdentity: privateKey,
+		OutputDir:       outputDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected malformed JSONL validation error, got %v", err)
+	}
+
+	if _, err := os.Stat(outputDir); !os.IsNotExist(err) {
+		t.Fatalf("malformed collection was promoted to output dir: %v", err)
 	}
 }
 

--- a/retriever/archive_tar_test.go
+++ b/retriever/archive_tar_test.go
@@ -94,7 +94,7 @@ func TestCollectionTarRejectsUnsafeInputs(t *testing.T) {
 		"absolute":       "/tmp/fragment.gz",
 		"parent":         "../fragment.gz",
 		"nested parent":  "graphs/../fragment.gz",
-		"back separator": `graphs\default\nodes-000001.ogfrag.gz`,
+		"back separator": `graphs\default\nodes-000001.jsonl.gz`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			dir := writeManifestWithArchivePath(t, archivePath)

--- a/retriever/compression.go
+++ b/retriever/compression.go
@@ -1,6 +1,7 @@
 package retriever
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
@@ -20,6 +21,19 @@ const DefaultZstdLevel = 11
 type countingWriter struct {
 	writer io.Writer
 	count  int64
+}
+
+type compressedJSONLinesWriter struct {
+	path                string
+	tempPath            string
+	file                *os.File
+	compressor          io.WriteCloser
+	encoder             *json.Encoder
+	compressedCounter   *countingWriter
+	uncompressedCounter *countingWriter
+	hasher              hash.Hash
+	count               int
+	closed              bool
 }
 
 func (s *countingWriter) Write(p []byte) (int, error) {
@@ -79,96 +93,220 @@ func newDecompressionReader(reader io.Reader, codec CompressionCodec) (io.ReadCl
 	}
 }
 
-func encodeCompactJSON(value any) ([]byte, error) {
-	var buffer bytes.Buffer
-	encoder := json.NewEncoder(&buffer)
-	encoder.SetEscapeHTML(false)
-
-	if err := encoder.Encode(value); err != nil {
-		return nil, err
-	}
-
-	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
-}
-
-func writeCompressedJSON(path string, codec CompressionCodec, zstdLevel int, value any) (FileManifest, error) {
-	payload, err := encodeCompactJSON(value)
-	if err != nil {
-		return FileManifest{}, fmt.Errorf("encode fragment: %w", err)
-	}
-
+func newCompressedJSONLinesWriter(path string, codec CompressionCodec, zstdLevel int) (*compressedJSONLinesWriter, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return FileManifest{}, fmt.Errorf("create fragment directory: %w", err)
+		return nil, fmt.Errorf("create fragment directory: %w", err)
 	}
 
 	tempPath := path + ".tmp"
 	file, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
-		return FileManifest{}, fmt.Errorf("open fragment temp file: %w", err)
+		return nil, fmt.Errorf("open fragment temp file: %w", err)
 	}
 
 	hasher := sha256.New()
-	counter := &countingWriter{
+	compressedCounter := &countingWriter{
 		writer: io.MultiWriter(file, hasher),
 	}
-	compressor, err := newCompressionWriter(counter, codec, zstdLevel)
+	compressor, err := newCompressionWriter(compressedCounter, codec, zstdLevel)
 	if err != nil {
-		file.Close()
-		os.Remove(tempPath)
+		_ = file.Close()
+		_ = os.Remove(tempPath)
 
-		return FileManifest{}, err
+		return nil, err
 	}
 
-	_, writeErr := compressor.Write(payload)
-	closeCompressionErr := compressor.Close()
-	closeFileErr := file.Close()
+	uncompressedCounter := &countingWriter{
+		writer: compressor,
+	}
+	encoder := json.NewEncoder(uncompressedCounter)
+	encoder.SetEscapeHTML(false)
 
-	if writeErr != nil {
-		os.Remove(tempPath)
-		return FileManifest{}, fmt.Errorf("write compressed fragment: %w", writeErr)
+	return &compressedJSONLinesWriter{
+		path:                path,
+		tempPath:            tempPath,
+		file:                file,
+		compressor:          compressor,
+		encoder:             encoder,
+		compressedCounter:   compressedCounter,
+		uncompressedCounter: uncompressedCounter,
+		hasher:              hasher,
+	}, nil
+}
+
+func (s *compressedJSONLinesWriter) Write(value any) error {
+	if s.closed {
+		return fmt.Errorf("write closed JSONL fragment")
 	}
 
-	if closeCompressionErr != nil {
-		os.Remove(tempPath)
-		return FileManifest{}, fmt.Errorf("finish compressed fragment: %w", closeCompressionErr)
+	if err := s.encoder.Encode(value); err != nil {
+		return fmt.Errorf("encode JSONL record %d: %w", s.count+1, err)
 	}
 
-	if closeFileErr != nil {
-		os.Remove(tempPath)
-		return FileManifest{}, fmt.Errorf("close fragment file: %w", closeFileErr)
+	s.count++
+
+	return nil
+}
+
+func (s *compressedJSONLinesWriter) Count() int {
+	return s.count
+}
+
+func (s *compressedJSONLinesWriter) Close() (FileManifest, error) {
+	if s.closed {
+		return FileManifest{}, fmt.Errorf("close JSONL fragment more than once")
+	}
+	s.closed = true
+
+	if err := s.compressor.Close(); err != nil {
+		_ = s.file.Close()
+		_ = os.Remove(s.tempPath)
+
+		return FileManifest{}, fmt.Errorf("finish compressed fragment: %w", err)
 	}
 
-	if err := os.Rename(tempPath, path); err != nil {
-		os.Remove(tempPath)
+	if err := s.file.Close(); err != nil {
+		_ = os.Remove(s.tempPath)
+
+		return FileManifest{}, fmt.Errorf("close fragment file: %w", err)
+	}
+
+	if err := os.Rename(s.tempPath, s.path); err != nil {
+		_ = os.Remove(s.tempPath)
+
 		return FileManifest{}, fmt.Errorf("rename fragment: %w", err)
 	}
 
 	return FileManifest{
-		CompressedBytes:   counter.count,
-		UncompressedBytes: int64(len(payload)),
-		SHA256:            hex.EncodeToString(hasher.Sum(nil)),
+		Count:             s.count,
+		CompressedBytes:   s.compressedCounter.count,
+		UncompressedBytes: s.uncompressedCounter.count,
+		SHA256:            hex.EncodeToString(s.hasher.Sum(nil)),
 	}, nil
 }
 
-func readCompressedJSON(path string, codec CompressionCodec, target any) error {
+func (s *compressedJSONLinesWriter) Abort() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+
+	_ = s.compressor.Close()
+	_ = s.file.Close()
+	_ = os.Remove(s.tempPath)
+}
+
+func writeCompressedJSONLines[T any](path string, codec CompressionCodec, zstdLevel int, records []T) (FileManifest, error) {
+	writer, err := newCompressedJSONLinesWriter(path, codec, zstdLevel)
+	if err != nil {
+		return FileManifest{}, err
+	}
+
+	for _, record := range records {
+		if err := writer.Write(record); err != nil {
+			writer.Abort()
+
+			return FileManifest{}, err
+		}
+	}
+
+	return writer.Close()
+}
+
+func readCompressedJSONLines[T any](path string, codec CompressionCodec, handle func(T) error) (int, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("open fragment: %w", err)
+		return 0, fmt.Errorf("open fragment: %w", err)
 	}
 	defer file.Close()
 
-	reader, err := newDecompressionReader(file, codec)
+	return readCompressedJSONLinesFromReader(file, codec, handle)
+}
+
+func readVerifiedCompressedJSONLines[T any](path string, codec CompressionCodec, expectedSHA256 string, expectedCompressedBytes int64, handle func(T) error) (int, error) {
+	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("open compressed fragment: %w", err)
+		return 0, fmt.Errorf("open fragment: %w", err)
 	}
-	defer reader.Close()
+	defer file.Close()
 
-	decoder := json.NewDecoder(reader)
-	if err := decoder.Decode(target); err != nil {
-		return fmt.Errorf("decode fragment: %w", err)
+	hasher := sha256.New()
+	compressedCounter := &countingWriter{
+		writer: hasher,
+	}
+	trackedReader := io.TeeReader(file, compressedCounter)
+
+	count, decodeErr := readCompressedJSONLinesFromReader(trackedReader, codec, handle)
+	if _, err := io.Copy(io.Discard, trackedReader); err != nil {
+		return count, fmt.Errorf("hash checksum target: %w", err)
 	}
 
-	return nil
+	if err := verifyChecksumValues(path, expectedSHA256, expectedCompressedBytes, hex.EncodeToString(hasher.Sum(nil)), compressedCounter.count); err != nil {
+		return count, err
+	}
+
+	return count, decodeErr
+}
+
+func readCompressedJSONLinesFromReader[T any](reader io.Reader, codec CompressionCodec, handle func(T) error) (int, error) {
+	decompressor, err := newDecompressionReader(reader, codec)
+	if err != nil {
+		return 0, fmt.Errorf("open compressed fragment: %w", err)
+	}
+
+	bufferedReader := bufio.NewReader(decompressor)
+	count := 0
+	var decodeErr error
+	for {
+		line, readErr := bufferedReader.ReadBytes('\n')
+		if len(line) > 0 {
+			line = bytes.TrimSuffix(line, []byte{'\n'})
+			line = bytes.TrimSuffix(line, []byte{'\r'})
+			if len(bytes.TrimSpace(line)) == 0 {
+				decodeErr = fmt.Errorf("decode JSONL record %d: blank line", count+1)
+				break
+			}
+
+			var record T
+			decoder := json.NewDecoder(bytes.NewReader(line))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&record); err != nil {
+				decodeErr = fmt.Errorf("decode JSONL record %d: %w", count+1, err)
+				break
+			}
+			if err := decoder.Decode(&struct{}{}); err != io.EOF {
+				if err == nil {
+					decodeErr = fmt.Errorf("decode JSONL record %d: multiple JSON values", count+1)
+					break
+				}
+
+				decodeErr = fmt.Errorf("decode JSONL record %d: %w", count+1, err)
+				break
+			}
+
+			count++
+			if handle != nil {
+				if err := handle(record); err != nil {
+					decodeErr = err
+					break
+				}
+			}
+		}
+
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			decodeErr = fmt.Errorf("read JSONL record %d: %w", count+1, readErr)
+			break
+		}
+	}
+
+	if err := decompressor.Close(); decodeErr == nil && err != nil {
+		return count, fmt.Errorf("close compressed fragment: %w", err)
+	}
+
+	return count, decodeErr
 }
 
 func verifyChecksum(path string, expectedSHA256 string, expectedCompressedBytes int64) error {
@@ -184,20 +322,23 @@ func verifyChecksum(path string, expectedSHA256 string, expectedCompressedBytes 
 		return fmt.Errorf("hash checksum target: %w", err)
 	}
 
-	if expectedCompressedBytes >= 0 && copied != expectedCompressedBytes {
+	return verifyChecksumValues(path, expectedSHA256, expectedCompressedBytes, hex.EncodeToString(hasher.Sum(nil)), copied)
+}
+
+func verifyChecksumValues(path string, expectedSHA256 string, expectedCompressedBytes int64, actualSHA256 string, actualCompressedBytes int64) error {
+	if expectedCompressedBytes >= 0 && actualCompressedBytes != expectedCompressedBytes {
 		return ByteCountMismatchError{
 			Path:          path,
 			ExpectedBytes: expectedCompressedBytes,
-			ActualBytes:   copied,
+			ActualBytes:   actualCompressedBytes,
 		}
 	}
 
-	actual := hex.EncodeToString(hasher.Sum(nil))
-	if actual != expectedSHA256 {
+	if actualSHA256 != expectedSHA256 {
 		return ChecksumMismatchError{
 			Path:           path,
 			ExpectedSHA256: expectedSHA256,
-			ActualSHA256:   actual,
+			ActualSHA256:   actualSHA256,
 		}
 	}
 
@@ -208,30 +349,34 @@ func copyHash(hasher hash.Hash, reader io.Reader) (int64, error) {
 	return io.Copy(hasher, reader)
 }
 
-func compressedJSONSize(codec CompressionCodec, zstdLevel int, value any) (int64, int64, error) {
-	payload, err := encodeCompactJSON(value)
-	if err != nil {
-		return 0, 0, err
-	}
-
+func compressedJSONLinesSize[T any](codec CompressionCodec, zstdLevel int, records []T) (int64, int64, error) {
 	var buffer bytes.Buffer
 	compressor, err := newCompressionWriter(&buffer, codec, zstdLevel)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	if _, err := compressor.Write(payload); err != nil {
-		compressor.Close()
-		return 0, 0, err
+	uncompressedCounter := &countingWriter{
+		writer: compressor,
+	}
+	encoder := json.NewEncoder(uncompressedCounter)
+	encoder.SetEscapeHTML(false)
+
+	for index, record := range records {
+		if err := encoder.Encode(record); err != nil {
+			_ = compressor.Close()
+
+			return 0, 0, fmt.Errorf("encode JSONL record %d: %w", index+1, err)
+		}
 	}
 
 	if err := compressor.Close(); err != nil {
 		return 0, 0, err
 	}
 
-	return int64(len(payload)), int64(buffer.Len()), nil
+	return uncompressedCounter.count, int64(buffer.Len()), nil
 }
 
-func CompressedJSONSize(codec CompressionCodec, zstdLevel int, value any) (int64, int64, error) {
-	return compressedJSONSize(codec, zstdLevel, value)
+func CompressedJSONLinesSize[T any](codec CompressionCodec, zstdLevel int, records []T) (int64, int64, error) {
+	return compressedJSONLinesSize(codec, zstdLevel, records)
 }

--- a/retriever/compression.go
+++ b/retriever/compression.go
@@ -16,7 +16,10 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-const DefaultZstdLevel = 11
+const (
+	DefaultZstdLevel  = 11
+	maxJSONLLineBytes = 10 * 1024 * 1024
+)
 
 type countingWriter struct {
 	writer io.Writer
@@ -254,52 +257,44 @@ func readCompressedJSONLinesFromReader[T any](reader io.Reader, codec Compressio
 		return 0, fmt.Errorf("open compressed fragment: %w", err)
 	}
 
-	bufferedReader := bufio.NewReader(decompressor)
+	scanner := bufio.NewScanner(decompressor)
+	scanner.Buffer(make([]byte, maxJSONLLineBytes), maxJSONLLineBytes)
 	count := 0
 	var decodeErr error
-	for {
-		line, readErr := bufferedReader.ReadBytes('\n')
-		if len(line) > 0 {
-			line = bytes.TrimSuffix(line, []byte{'\n'})
-			line = bytes.TrimSuffix(line, []byte{'\r'})
-			if len(bytes.TrimSpace(line)) == 0 {
-				decodeErr = fmt.Errorf("decode JSONL record %d: blank line", count+1)
-				break
-			}
-
-			var record T
-			decoder := json.NewDecoder(bytes.NewReader(line))
-			decoder.DisallowUnknownFields()
-			if err := decoder.Decode(&record); err != nil {
-				decodeErr = fmt.Errorf("decode JSONL record %d: %w", count+1, err)
-				break
-			}
-			if err := decoder.Decode(&struct{}{}); err != io.EOF {
-				if err == nil {
-					decodeErr = fmt.Errorf("decode JSONL record %d: multiple JSON values", count+1)
-					break
-				}
-
-				decodeErr = fmt.Errorf("decode JSONL record %d: %w", count+1, err)
-				break
-			}
-
-			count++
-			if handle != nil {
-				if err := handle(record); err != nil {
-					decodeErr = err
-					break
-				}
-			}
-		}
-
-		if readErr == io.EOF {
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			decodeErr = fmt.Errorf("decode JSONL record %d: blank line", count+1)
 			break
 		}
-		if readErr != nil {
-			decodeErr = fmt.Errorf("read JSONL record %d: %w", count+1, readErr)
+
+		var record T
+		decoder := json.NewDecoder(bytes.NewReader(line))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&record); err != nil {
+			decodeErr = fmt.Errorf("decode JSONL record %d: %w", count+1, err)
 			break
 		}
+		if err := decoder.Decode(&struct{}{}); err != io.EOF {
+			if err == nil {
+				decodeErr = fmt.Errorf("decode JSONL record %d: multiple JSON values", count+1)
+				break
+			}
+
+			decodeErr = fmt.Errorf("decode JSONL record %d: %w", count+1, err)
+			break
+		}
+
+		count++
+		if handle != nil {
+			if err := handle(record); err != nil {
+				decodeErr = err
+				break
+			}
+		}
+	}
+	if err := scanner.Err(); decodeErr == nil && err != nil {
+		decodeErr = fmt.Errorf("read JSONL record %d: %w", count+1, err)
 	}
 
 	if err := decompressor.Close(); decodeErr == nil && err != nil {

--- a/retriever/compression_test.go
+++ b/retriever/compression_test.go
@@ -234,6 +234,24 @@ func TestReadCompressedJSONLinesSupportsLargeRecords(t *testing.T) {
 	}
 }
 
+func TestReadCompressedJSONLinesRejectsLineLargerThanBuffer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "too-large.gz")
+	payload := `{"id":"1","kinds":[],"properties":{"description":"` +
+		strings.Repeat("x", maxJSONLLineBytes) + `"}}` + "\n"
+	writeCompressedPayload(t, path, CompressionGzip, payload)
+
+	count, err := readCompressedJSONLines[FragmentNode](path, CompressionGzip, nil)
+	if err == nil {
+		t.Fatal("expected oversized line to fail")
+	}
+	if count != 0 {
+		t.Fatalf("record count = %d, want 0", count)
+	}
+	if !strings.Contains(err.Error(), "read JSONL record 1") || !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("unexpected oversized-line error: %v", err)
+	}
+}
+
 func TestCompressedJSONLinesWriterAbort(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "fragment.gz")
 	writer, err := newCompressedJSONLinesWriter(path, CompressionGzip, DefaultZstdLevel)

--- a/retriever/compression_test.go
+++ b/retriever/compression_test.go
@@ -9,24 +9,29 @@ import (
 	"testing"
 )
 
-func TestCompressedJSONRoundTrip(t *testing.T) {
+func TestCompressedJSONLinesRoundTrip(t *testing.T) {
 	for _, codec := range []CompressionCodec{CompressionGzip, CompressionZstd} {
 		t.Run(string(codec), func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "fragment")
-			entry, err := writeCompressedJSON(path, codec, DefaultZstdLevel, NodeFragment{
-				Phase: PhaseNodes,
-				Items: []FragmentNode{{
+			records := []FragmentNode{
+				{
 					ID:         "1",
 					Kinds:      []string{"User"},
 					Properties: map[string]any{"name": "alice"},
-				}},
-			})
-			if err != nil {
-				t.Fatalf("write compressed JSON: %v", err)
+				},
+				{
+					ID:    "2",
+					Kinds: []string{"Computer"},
+				},
 			}
 
-			if entry.SHA256 == "" {
-				t.Fatalf("expected checksum")
+			entry, err := writeCompressedJSONLines(path, codec, DefaultZstdLevel, records)
+			if err != nil {
+				t.Fatalf("write compressed JSONL: %v", err)
+			}
+
+			if entry.Count != len(records) || entry.SHA256 == "" {
+				t.Fatalf("unexpected fragment metadata: %+v", entry)
 			}
 
 			if entry.CompressedBytes <= 0 || entry.UncompressedBytes <= 0 {
@@ -37,13 +42,18 @@ func TestCompressedJSONRoundTrip(t *testing.T) {
 				t.Fatalf("verify checksum: %v", err)
 			}
 
-			var decoded NodeFragment
-			if err := readCompressedJSON(path, codec, &decoded); err != nil {
-				t.Fatalf("read compressed JSON: %v", err)
+			var decoded []FragmentNode
+			count, err := readCompressedJSONLines(path, codec, func(record FragmentNode) error {
+				decoded = append(decoded, record)
+
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("read compressed JSONL: %v", err)
 			}
 
-			if decoded.Phase != PhaseNodes || len(decoded.Items) != 1 || decoded.Items[0].ID != "1" {
-				t.Fatalf("unexpected decoded fragment: %+v", decoded)
+			if count != 2 || len(decoded) != 2 || decoded[0].ID != "1" || decoded[1].ID != "2" {
+				t.Fatalf("unexpected decoded records: %+v", decoded)
 			}
 		})
 	}
@@ -51,16 +61,13 @@ func TestCompressedJSONRoundTrip(t *testing.T) {
 
 func TestVerifyChecksumFailure(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "fragment")
-	entry, err := writeCompressedJSON(path, CompressionGzip, DefaultZstdLevel, EdgeFragment{
-		Phase: PhaseEdges,
-		Items: []FragmentEdge{{
-			StartID: "1",
-			EndID:   "2",
-			Kind:    "AdminTo",
-		}},
-	})
+	entry, err := writeCompressedJSONLines(path, CompressionGzip, DefaultZstdLevel, []FragmentEdge{{
+		StartID: "1",
+		EndID:   "2",
+		Kind:    "AdminTo",
+	}})
 	if err != nil {
-		t.Fatalf("write compressed JSON: %v", err)
+		t.Fatalf("write compressed JSONL: %v", err)
 	}
 
 	if err := verifyChecksum(path, entry.SHA256, entry.CompressedBytes+1); err == nil {
@@ -109,67 +116,171 @@ func TestCompressionUnsupportedCodec(t *testing.T) {
 	}
 }
 
-func TestReadCompressedJSONRejectsCorruptPayload(t *testing.T) {
+func TestReadCompressedJSONLinesRejectsCorruptPayload(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bad.gz")
 	if err := os.WriteFile(path, []byte("not gzip"), 0o600); err != nil {
 		t.Fatalf("write corrupt payload: %v", err)
 	}
 
-	var fragment NodeFragment
-	if err := readCompressedJSON(path, CompressionGzip, &fragment); err == nil {
+	if _, err := readCompressedJSONLines[FragmentNode](path, CompressionGzip, nil); err == nil {
 		t.Fatalf("expected corrupt gzip error")
 	}
 }
 
-func TestEmptyFragmentRoundTrip(t *testing.T) {
+func TestEmptyJSONLinesFragmentRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "empty.zst")
-	_, err := writeCompressedJSON(path, CompressionZstd, DefaultZstdLevel, EdgeFragment{
-		Phase: PhaseEdges,
-		Items: nil,
-	})
+	entry, err := writeCompressedJSONLines(path, CompressionZstd, DefaultZstdLevel, []FragmentEdge(nil))
 	if err != nil {
 		t.Fatalf("write empty fragment: %v", err)
 	}
 
-	var decoded EdgeFragment
-
-	if err := readCompressedJSON(path, CompressionZstd, &decoded); err != nil {
+	count, err := readCompressedJSONLines[FragmentEdge](path, CompressionZstd, nil)
+	if err != nil {
 		t.Fatalf("read empty fragment: %v", err)
 	}
 
-	if decoded.Phase != PhaseEdges || len(decoded.Items) != 0 {
-		t.Fatalf("unexpected empty fragment decode: %+v", decoded)
+	if entry.Count != 0 || entry.UncompressedBytes != 0 || count != 0 {
+		t.Fatalf("unexpected empty fragment metadata: entry=%+v count=%d", entry, count)
 	}
 }
 
-func TestCompressedJSONSizeAndCompactEncoding(t *testing.T) {
-	fragment := NodeFragment{
-		Phase: PhaseNodes,
-		Items: []FragmentNode{{
-			ID:    "1",
-			Kinds: []string{"User"},
-		}},
-	}
+func TestCompressedJSONLinesSize(t *testing.T) {
+	records := []FragmentNode{{
+		ID:    "1",
+		Kinds: []string{"User"},
+	}}
+	expectedPayload := "{\"id\":\"1\",\"kinds\":[\"User\"]}\n"
 
-	payload, err := encodeCompactJSON(fragment)
+	uncompressedBytes, compressedBytes, err := compressedJSONLinesSize(CompressionGzip, DefaultZstdLevel, records)
 	if err != nil {
-		t.Fatalf("encode compact JSON: %v", err)
+		t.Fatalf("compressed JSONL size: %v", err)
 	}
 
-	if strings.Contains(string(payload), "\n") || strings.Contains(string(payload), "  ") {
-		t.Fatalf("expected compact JSON, got %q", payload)
-	}
-
-	uncompressedBytes, compressedBytes, err := compressedJSONSize(CompressionGzip, DefaultZstdLevel, fragment)
-	if err != nil {
-		t.Fatalf("compressed JSON size: %v", err)
-	}
-
-	if uncompressedBytes != int64(len(payload)) {
-		t.Fatalf("uncompressed bytes = %d, want %d", uncompressedBytes, len(payload))
+	if uncompressedBytes != int64(len(expectedPayload)) {
+		t.Fatalf("uncompressed bytes = %d, want %d", uncompressedBytes, len(expectedPayload))
 	}
 
 	if compressedBytes <= 0 {
 		t.Fatalf("expected compressed bytes > 0")
+	}
+}
+
+func TestReadCompressedJSONLinesValidatesPhysicalLines(t *testing.T) {
+	tests := map[string]struct {
+		payload string
+		wantErr string
+		want    int
+	}{
+		"blank line": {
+			payload: "{\"id\":\"1\",\"kinds\":[]}\n\n",
+			wantErr: "blank line",
+		},
+		"malformed record": {
+			payload: "{\"id\":\"1\",\"kinds\":[]}\n{bad}\n",
+			wantErr: "record 2",
+		},
+		"unknown field": {
+			payload: "{\"phase\":\"nodes\",\"items\":[]}\n",
+			wantErr: "unknown field",
+		},
+		"multiple values": {
+			payload: "{\"id\":\"1\",\"kinds\":[]} {}\n",
+			wantErr: "record 1",
+		},
+		"missing final newline": {
+			payload: "{\"id\":\"1\",\"kinds\":[]}",
+			want:    1,
+		},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "fragment.gz")
+			writeCompressedPayload(t, path, CompressionGzip, testCase.payload)
+
+			count, err := readCompressedJSONLines[FragmentNode](path, CompressionGzip, nil)
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("read JSONL: %v", err)
+				}
+				if count != testCase.want {
+					t.Fatalf("record count = %d, want %d", count, testCase.want)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", testCase.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestReadCompressedJSONLinesSupportsLargeRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.gz")
+	records := []FragmentNode{{
+		ID:         "1",
+		Kinds:      []string{"User"},
+		Properties: map[string]any{"description": strings.Repeat("x", 1024*1024)},
+	}}
+
+	if _, err := writeCompressedJSONLines(path, CompressionGzip, DefaultZstdLevel, records); err != nil {
+		t.Fatalf("write large record: %v", err)
+	}
+
+	count, err := readCompressedJSONLines[FragmentNode](path, CompressionGzip, nil)
+	if err != nil {
+		t.Fatalf("read large record: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("record count = %d", count)
+	}
+}
+
+func TestCompressedJSONLinesWriterAbort(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fragment.gz")
+	writer, err := newCompressedJSONLinesWriter(path, CompressionGzip, DefaultZstdLevel)
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+
+	if err := writer.Write(FragmentNode{ID: "1"}); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+	writer.Abort()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected final path to be absent, got %v", err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("expected temporary path to be absent, got %v", err)
+	}
+	if err := writer.Write(FragmentNode{ID: "2"}); err == nil {
+		t.Fatalf("expected write after abort to fail")
+	}
+}
+
+func writeCompressedPayload(t *testing.T, path string, codec CompressionCodec, payload string) {
+	t.Helper()
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open compressed payload: %v", err)
+	}
+
+	compressor, err := newCompressionWriter(file, codec, DefaultZstdLevel)
+	if err != nil {
+		_ = file.Close()
+		t.Fatalf("open compressor: %v", err)
+	}
+
+	if _, err := compressor.Write([]byte(payload)); err != nil {
+		_ = compressor.Close()
+		_ = file.Close()
+		t.Fatalf("write compressed payload: %v", err)
+	}
+	if err := compressor.Close(); err != nil {
+		_ = file.Close()
+		t.Fatalf("close compressor: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close compressed payload: %v", err)
 	}
 }

--- a/retriever/doc.go
+++ b/retriever/doc.go
@@ -2,8 +2,8 @@
 // manifest-based retriever collection format.
 //
 // The primary database operations accept an already-open graph.Database. The
-// package also exposes the collection manifest and fragment structs for callers
-// that need to inspect or transform collection contents directly.
+// package also exposes the collection manifest and JSONL record structs for
+// callers that need to inspect or transform collection contents directly.
 //
 // Default option constructors mirror the CLI defaults. Callers can attach a
 // ProgressFunc to receive structured operation, phase, archive, and periodic

--- a/retriever/dump.go
+++ b/retriever/dump.go
@@ -476,24 +476,25 @@ func dumpNodePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 	}
 
 	var (
-		files []FileManifest
-		items []FragmentNode
-
-		shardActionCounts = map[string]int{}
-		shardNumber       = 1
+		files                []FileManifest
+		fragmentWriter       *compressedJSONLinesWriter
+		fragmentRelativePath string
+		shardActionCounts    = map[string]int{}
+		shardNumber          = 1
 	)
 
 	flush := func() error {
-		if len(items) == 0 {
+		if fragmentWriter == nil {
 			return nil
 		}
-		fileEntry, err := writeNodeFragment(options.OutputDir, targetGraph.Name, shardNumber, options, items, shardActionCounts)
+
+		fileEntry, err := closeFragmentWriter(fragmentWriter, fragmentRelativePath, PhaseNodes, shardActionCounts)
+		fragmentWriter = nil
 		if err != nil {
 			return err
 		}
 
 		files = append(files, fileEntry)
-		items = nil
 		shardActionCounts = map[string]int{}
 		shardNumber++
 
@@ -502,6 +503,16 @@ func dumpNodePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 
 	if _, err := scanDatabaseNodesWithProgressInterval(ctx, db, targetGraph, entitySnapshot.NodeCount, options.BatchSize, options.ProgressInterval, func(nodes []*graph.Node) error {
 		for _, node := range nodes {
+			if fragmentWriter == nil {
+				nextWriter, nextRelativePath, err := openFragmentWriter(options.OutputDir, targetGraph.Name, PhaseNodes, shardNumber, options)
+				if err != nil {
+					return err
+				}
+
+				fragmentWriter = nextWriter
+				fragmentRelativePath = nextRelativePath
+			}
+
 			kinds := node.Kinds.Strings()
 			sort.Strings(kinds)
 			addKindsToSet(nodeKinds, kinds)
@@ -524,9 +535,11 @@ func dumpNodePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 				return err
 			}
 
-			items = append(items, item)
+			if err := fragmentWriter.Write(item); err != nil {
+				return err
+			}
 
-			if len(items) >= options.ShardSize {
+			if fragmentWriter.Count() >= options.ShardSize {
 				if err := flush(); err != nil {
 					return err
 				}
@@ -537,6 +550,10 @@ func dumpNodePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 	}, func(processed int64, startedAt time.Time, nextProgressAt int64) int64 {
 		return logRetrieverEntityProgressInterval("retriever dump node phase progress", targetGraph.Name, PhaseNodes, processed, entitySnapshot.NodeCount, startedAt, nextProgressAt, options.Progress, options.ProgressInterval)
 	}); err != nil {
+		if fragmentWriter != nil {
+			fragmentWriter.Abort()
+		}
+
 		return nil, err
 	}
 
@@ -553,24 +570,25 @@ func dumpEdgePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 	}
 
 	var (
-		files []FileManifest
-		items []FragmentEdge
-
-		shardActionCounts = map[string]int{}
-		shardNumber       = 1
+		files                []FileManifest
+		fragmentWriter       *compressedJSONLinesWriter
+		fragmentRelativePath string
+		shardActionCounts    = map[string]int{}
+		shardNumber          = 1
 	)
 
 	flush := func() error {
-		if len(items) == 0 {
+		if fragmentWriter == nil {
 			return nil
 		}
-		fileEntry, err := writeEdgeFragment(options.OutputDir, targetGraph.Name, shardNumber, options, items, shardActionCounts)
+
+		fileEntry, err := closeFragmentWriter(fragmentWriter, fragmentRelativePath, PhaseEdges, shardActionCounts)
+		fragmentWriter = nil
 		if err != nil {
 			return err
 		}
 
 		files = append(files, fileEntry)
-		items = nil
 		shardActionCounts = map[string]int{}
 		shardNumber++
 
@@ -579,6 +597,16 @@ func dumpEdgePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 
 	if _, err := scanDatabaseRelationshipsWithProgressInterval(ctx, db, targetGraph, entitySnapshot.EdgeCount, options.BatchSize, options.ProgressInterval, func(relationships []*graph.Relationship) error {
 		for _, relationship := range relationships {
+			if fragmentWriter == nil {
+				nextWriter, nextRelativePath, err := openFragmentWriter(options.OutputDir, targetGraph.Name, PhaseEdges, shardNumber, options)
+				if err != nil {
+					return err
+				}
+
+				fragmentWriter = nextWriter
+				fragmentRelativePath = nextRelativePath
+			}
+
 			kind := ""
 			if relationship.Kind != nil {
 				kind = relationship.Kind.String()
@@ -604,9 +632,11 @@ func dumpEdgePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 				return err
 			}
 
-			items = append(items, item)
+			if err := fragmentWriter.Write(item); err != nil {
+				return err
+			}
 
-			if len(items) >= options.ShardSize {
+			if fragmentWriter.Count() >= options.ShardSize {
 				if err := flush(); err != nil {
 					return err
 				}
@@ -617,6 +647,10 @@ func dumpEdgePhase(ctx context.Context, db graph.Database, targetGraph graph.Gra
 	}, func(processed int64, startedAt time.Time, nextProgressAt int64) int64 {
 		return logRetrieverEntityProgressInterval("retriever dump edge phase progress", targetGraph.Name, PhaseEdges, processed, entitySnapshot.EdgeCount, startedAt, nextProgressAt, options.Progress, options.ProgressInterval)
 	}); err != nil {
+		if fragmentWriter != nil {
+			fragmentWriter.Abort()
+		}
+
 		return nil, err
 	}
 
@@ -634,10 +668,7 @@ func writeNodeFragment(outputDir, graphName string, shardNumber int, options Dum
 	}
 
 	absolutePath := filepath.Join(outputDir, filepath.FromSlash(relativePath))
-	fileEntry, err := writeCompressedJSON(absolutePath, options.Compression, options.ZstdLevel, NodeFragment{
-		Phase: PhaseNodes,
-		Items: items,
-	})
+	fileEntry, err := writeCompressedJSONLines(absolutePath, options.Compression, options.ZstdLevel, items)
 	if err != nil {
 		return FileManifest{}, err
 	}
@@ -657,10 +688,7 @@ func writeEdgeFragment(outputDir, graphName string, shardNumber int, options Dum
 	}
 
 	absolutePath := filepath.Join(outputDir, filepath.FromSlash(relativePath))
-	fileEntry, err := writeCompressedJSON(absolutePath, options.Compression, options.ZstdLevel, EdgeFragment{
-		Phase: PhaseEdges,
-		Items: items,
-	})
+	fileEntry, err := writeCompressedJSONLines(absolutePath, options.Compression, options.ZstdLevel, items)
 	if err != nil {
 		return FileManifest{}, err
 	}
@@ -693,7 +721,35 @@ func fragmentPath(graphName string, fragmentPhase Phase, shardNumber int, codec 
 		return "", fmt.Errorf("unsupported fragment phase %q", fragmentPhase)
 	}
 
-	return path.Join("graphs", graphDirectoryName(graphName), fmt.Sprintf("%s-%06d.ogfrag%s", prefix, shardNumber, extension)), nil
+	return path.Join("graphs", graphDirectoryName(graphName), fmt.Sprintf("%s-%06d.jsonl%s", prefix, shardNumber, extension)), nil
+}
+
+func openFragmentWriter(outputDir, graphName string, fragmentPhase Phase, shardNumber int, options DumpOptions) (*compressedJSONLinesWriter, string, error) {
+	relativePath, err := fragmentPath(graphName, fragmentPhase, shardNumber, options.Compression)
+	if err != nil {
+		return nil, "", err
+	}
+
+	absolutePath := filepath.Join(outputDir, filepath.FromSlash(relativePath))
+	writer, err := newCompressedJSONLinesWriter(absolutePath, options.Compression, options.ZstdLevel)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return writer, relativePath, nil
+}
+
+func closeFragmentWriter(writer *compressedJSONLinesWriter, relativePath string, fragmentPhase Phase, actionCounts map[string]int) (FileManifest, error) {
+	fileEntry, err := writer.Close()
+	if err != nil {
+		return FileManifest{}, err
+	}
+
+	fileEntry.Phase = fragmentPhase
+	fileEntry.Path = relativePath
+	fileEntry.ActionCounts = cloneActionCounts(actionCounts)
+
+	return fileEntry, nil
 }
 
 func fileTotal(files []FileManifest) int64 {

--- a/retriever/dump_test.go
+++ b/retriever/dump_test.go
@@ -10,7 +10,7 @@ func TestFragmentPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("node fragment path: %v", err)
 	}
-	if nodePath != "graphs/graph%2Fname/nodes-000007.ogfrag.zst" {
+	if nodePath != "graphs/graph%2Fname/nodes-000007.jsonl.zst" {
 		t.Fatalf("unexpected node fragment path %q", nodePath)
 	}
 
@@ -18,7 +18,7 @@ func TestFragmentPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("edge fragment path: %v", err)
 	}
-	if edgePath != "graphs/default/edges-000003.ogfrag.gz" {
+	if edgePath != "graphs/default/edges-000003.jsonl.gz" {
 		t.Fatalf("unexpected edge fragment path %q", edgePath)
 	}
 
@@ -45,7 +45,7 @@ func TestWriteFragmentMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("write node fragment: %v", err)
 	}
-	if fileEntry.Phase != PhaseNodes || fileEntry.Path != "graphs/default/nodes-000001.ogfrag.gz" || fileEntry.Count != 1 {
+	if fileEntry.Phase != PhaseNodes || fileEntry.Path != "graphs/default/nodes-000001.jsonl.gz" || fileEntry.Count != 1 {
 		t.Fatalf("unexpected node file Manifest: %+v", fileEntry)
 	}
 	if fileEntry.ActionCounts["pseudonymize"] != 1 {
@@ -63,7 +63,7 @@ func TestWriteFragmentMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("write edge fragment: %v", err)
 	}
-	if edgeEntry.Phase != PhaseEdges || edgeEntry.Path != "graphs/default/edges-000002.ogfrag.gz" || edgeEntry.Count != 1 {
+	if edgeEntry.Phase != PhaseEdges || edgeEntry.Path != "graphs/default/edges-000002.jsonl.gz" || edgeEntry.Count != 1 {
 		t.Fatalf("unexpected edge file Manifest: %+v", edgeEntry)
 	}
 }

--- a/retriever/load.go
+++ b/retriever/load.go
@@ -197,7 +197,27 @@ func readLoadManifest(inputDir string, driverName string) (Manifest, error) {
 }
 
 func verifyLoadFragments(inputDir string, nextManifest Manifest) error {
-	return verifyManifestFiles(inputDir, nextManifest)
+	return verifyCollectionFragments(inputDir, nextManifest)
+}
+
+func verifyCollectionFragments(inputDir string, nextManifest Manifest) error {
+	for _, graphEntry := range nextManifest.Graphs {
+		for _, fileEntry := range graphEntry.Files {
+			switch fileEntry.Phase {
+			case PhaseNodes:
+				if _, err := verifyNodeFragmentFile(inputDir, nextManifest.Compression, fileEntry); err != nil {
+					return err
+				}
+
+			case PhaseEdges:
+				if _, err := verifyEdgeFragmentFile(inputDir, nextManifest.Compression, fileEntry); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 type graphEntitySnapshotCounter func(context.Context, graph.Database, graph.Graph) (graphEntitySnapshot, error)
@@ -516,21 +536,13 @@ func loadGraphNodes(ctx context.Context, db graph.Database, inputDir string, cod
 			continue
 		}
 
-		fragment, err := readNodeFragmentFile(inputDir, codec, fileEntry)
-		if err != nil {
-			return nil, loaded, err
-		}
-
+		var fragmentCount int
 		if err := db.WriteTransaction(ctx, func(tx graph.Transaction) error {
 			tx = tx.WithGraph(graph.Graph{
 				Name: graphEntry.Name,
 			})
 
-			for _, item := range fragment.Items {
-				if item.ID == "" {
-					return fmt.Errorf("node fragment %s contains empty source ID", fileEntry.Path)
-				}
-
+			count, err := readNodeFragmentFile(inputDir, codec, fileEntry, func(item FragmentNode) error {
 				if _, exists := nodeMap[item.ID]; exists {
 					return fmt.Errorf("duplicate source node ID %q in graph %q", item.ID, graphEntry.Name)
 				}
@@ -541,14 +553,17 @@ func loadGraphNodes(ctx context.Context, db graph.Database, inputDir string, cod
 				}
 
 				nodeMap[item.ID] = dbNode.ID
-			}
 
-			return nil
+				return nil
+			})
+			fragmentCount = count
+
+			return err
 		}); err != nil {
 			return nil, loaded, fmt.Errorf("load node fragment %s: %w", fileEntry.Path, err)
 		}
 
-		loaded += int64(len(fragment.Items))
+		loaded += int64(fragmentCount)
 		nextProgressAt = logRetrieverEntityProgressInterval("retriever load node phase progress", graphEntry.Name, PhaseNodes, loaded, graphEntry.NodeCount, startedAt, nextProgressAt, progress, progressInterval)
 	}
 
@@ -568,17 +583,13 @@ func loadGraphEdges(ctx context.Context, db graph.Database, inputDir string, cod
 			continue
 		}
 
-		fragment, err := readEdgeFragmentFile(inputDir, codec, fileEntry)
-		if err != nil {
-			return loaded, err
-		}
-
+		var fragmentCount int
 		if err := db.BatchOperation(ctx, func(batch graph.Batch) error {
 			batch = batch.WithGraph(graph.Graph{
 				Name: graphEntry.Name,
 			})
 
-			for _, item := range fragment.Items {
+			count, err := readEdgeFragmentFile(inputDir, codec, fileEntry, func(item FragmentEdge) error {
 				resolved, err := resolveFragmentEdge(item, nodeMap)
 				if err != nil {
 					return err
@@ -587,52 +598,112 @@ func loadGraphEdges(ctx context.Context, db graph.Database, inputDir string, cod
 				if err := batch.CreateRelationshipByIDs(resolved.StartID, resolved.EndID, resolved.Kind, resolved.Properties); err != nil {
 					return fmt.Errorf("create edge (%s)-[%s]->(%s): %w", item.StartID, item.Kind, item.EndID, err)
 				}
-			}
 
-			return nil
+				return nil
+			})
+			fragmentCount = count
+
+			return err
 		}, graph.WithBatchSize(batchSize)); err != nil {
 			return loaded, fmt.Errorf("load edge fragment %s: %w", fileEntry.Path, err)
 		}
 
-		loaded += int64(len(fragment.Items))
+		loaded += int64(fragmentCount)
 		nextProgressAt = logRetrieverEntityProgressInterval("retriever load edge phase progress", graphEntry.Name, PhaseEdges, loaded, graphEntry.EdgeCount, startedAt, nextProgressAt, progress, progressInterval)
 	}
 
 	return loaded, nil
 }
 
-func readNodeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest) (NodeFragment, error) {
-	var fragment NodeFragment
-	if err := readCompressedJSON(filepath.Join(inputDir, filepath.FromSlash(fileEntry.Path)), codec, &fragment); err != nil {
-		return NodeFragment{}, fmt.Errorf("read node fragment %s: %w", fileEntry.Path, err)
-	}
-
-	if fragment.Phase != PhaseNodes {
-		return NodeFragment{}, fmt.Errorf("fragment %s has phase %q, expected nodes", fileEntry.Path, fragment.Phase)
-	}
-
-	if len(fragment.Items) != fileEntry.Count {
-		return NodeFragment{}, fmt.Errorf("fragment %s item count %d does not match manifest count %d", fileEntry.Path, len(fragment.Items), fileEntry.Count)
-	}
-
-	return fragment, nil
+func readNodeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest, handle func(FragmentNode) error) (int, error) {
+	return decodeNodeFragmentFile(inputDir, codec, fileEntry, false, handle)
 }
 
-func readEdgeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest) (EdgeFragment, error) {
-	var fragment EdgeFragment
-	if err := readCompressedJSON(filepath.Join(inputDir, filepath.FromSlash(fileEntry.Path)), codec, &fragment); err != nil {
-		return EdgeFragment{}, fmt.Errorf("read edge fragment %s: %w", fileEntry.Path, err)
+func verifyNodeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest) (int, error) {
+	return decodeNodeFragmentFile(inputDir, codec, fileEntry, true, nil)
+}
+
+func decodeNodeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest, verifyIntegrity bool, handle func(FragmentNode) error) (int, error) {
+	if fileEntry.Phase != PhaseNodes {
+		return 0, fmt.Errorf("fragment %s has phase %q, expected nodes", fileEntry.Path, fileEntry.Phase)
 	}
 
-	if fragment.Phase != PhaseEdges {
-		return EdgeFragment{}, fmt.Errorf("fragment %s has phase %q, expected edges", fileEntry.Path, fragment.Phase)
+	fragmentPath := filepath.Join(inputDir, filepath.FromSlash(fileEntry.Path))
+	validate := func(item FragmentNode) error {
+		if item.ID == "" {
+			return fmt.Errorf("node fragment %s contains empty source ID", fileEntry.Path)
+		}
+
+		if handle != nil {
+			return handle(item)
+		}
+
+		return nil
 	}
 
-	if len(fragment.Items) != fileEntry.Count {
-		return EdgeFragment{}, fmt.Errorf("fragment %s item count %d does not match manifest count %d", fileEntry.Path, len(fragment.Items), fileEntry.Count)
+	var count int
+	var err error
+	if verifyIntegrity {
+		count, err = readVerifiedCompressedJSONLines(fragmentPath, codec, fileEntry.SHA256, fileEntry.CompressedBytes, validate)
+	} else {
+		count, err = readCompressedJSONLines(fragmentPath, codec, validate)
+	}
+	if err != nil {
+		return count, fmt.Errorf("read node fragment %s: %w", fileEntry.Path, err)
 	}
 
-	return fragment, nil
+	if count != fileEntry.Count {
+		return count, fmt.Errorf("fragment %s item count %d does not match manifest count %d", fileEntry.Path, count, fileEntry.Count)
+	}
+
+	return count, nil
+}
+
+func readEdgeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest, handle func(FragmentEdge) error) (int, error) {
+	return decodeEdgeFragmentFile(inputDir, codec, fileEntry, false, handle)
+}
+
+func verifyEdgeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest) (int, error) {
+	return decodeEdgeFragmentFile(inputDir, codec, fileEntry, true, nil)
+}
+
+func decodeEdgeFragmentFile(inputDir string, codec CompressionCodec, fileEntry FileManifest, verifyIntegrity bool, handle func(FragmentEdge) error) (int, error) {
+	if fileEntry.Phase != PhaseEdges {
+		return 0, fmt.Errorf("fragment %s has phase %q, expected edges", fileEntry.Path, fileEntry.Phase)
+	}
+
+	fragmentPath := filepath.Join(inputDir, filepath.FromSlash(fileEntry.Path))
+	validate := func(item FragmentEdge) error {
+		if item.StartID == "" {
+			return fmt.Errorf("edge fragment %s contains empty start source ID", fileEntry.Path)
+		}
+		if item.EndID == "" {
+			return fmt.Errorf("edge fragment %s contains empty end source ID", fileEntry.Path)
+		}
+
+		if handle != nil {
+			return handle(item)
+		}
+
+		return nil
+	}
+
+	var count int
+	var err error
+	if verifyIntegrity {
+		count, err = readVerifiedCompressedJSONLines(fragmentPath, codec, fileEntry.SHA256, fileEntry.CompressedBytes, validate)
+	} else {
+		count, err = readCompressedJSONLines(fragmentPath, codec, validate)
+	}
+	if err != nil {
+		return count, fmt.Errorf("read edge fragment %s: %w", fileEntry.Path, err)
+	}
+
+	if count != fileEntry.Count {
+		return count, fmt.Errorf("fragment %s item count %d does not match manifest count %d", fileEntry.Path, count, fileEntry.Count)
+	}
+
+	return count, nil
 }
 
 func resolveFragmentEdge(item FragmentEdge, nodeMap map[string]graph.ID) (resolvedFragmentEdge, error) {

--- a/retriever/load_benchmark_test.go
+++ b/retriever/load_benchmark_test.go
@@ -1,0 +1,118 @@
+package retriever
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/specterops/dawgs/graph"
+)
+
+func BenchmarkLoadFragmentPath(b *testing.B) {
+	const (
+		nodeCount = 10_000
+		edgeCount = nodeCount - 1
+		shardSize = 2_500
+	)
+
+	dir := b.TempDir()
+	nodes := make([]FragmentNode, nodeCount)
+	for index := range nodes {
+		nodes[index] = FragmentNode{
+			ID:    strconv.Itoa(index),
+			Kinds: []string{"User"},
+			Properties: map[string]any{
+				"name": "user-" + strconv.Itoa(index),
+				"team": "team-" + strconv.Itoa(index%100),
+			},
+		}
+	}
+
+	edges := make([]FragmentEdge, edgeCount)
+	for index := range edges {
+		edges[index] = FragmentEdge{
+			StartID: strconv.Itoa(index),
+			EndID:   strconv.Itoa(index + 1),
+			Kind:    "ReportsTo",
+			Properties: map[string]any{
+				"source": "benchmark",
+			},
+		}
+	}
+
+	files := make([]FileManifest, 0, 8)
+	for start, shard := 0, 1; start < len(nodes); start, shard = start+shardSize, shard+1 {
+		end := min(start+shardSize, len(nodes))
+		path := "nodes-" + strconv.Itoa(shard) + ".jsonl.gz"
+		entry, err := writeCompressedJSONLines(filepath.Join(dir, path), CompressionGzip, DefaultZstdLevel, nodes[start:end])
+		if err != nil {
+			b.Fatalf("write node benchmark fragment: %v", err)
+		}
+		entry.Phase = PhaseNodes
+		entry.Path = path
+		files = append(files, entry)
+	}
+	for start, shard := 0, 1; start < len(edges); start, shard = start+shardSize, shard+1 {
+		end := min(start+shardSize, len(edges))
+		path := "edges-" + strconv.Itoa(shard) + ".jsonl.gz"
+		entry, err := writeCompressedJSONLines(filepath.Join(dir, path), CompressionGzip, DefaultZstdLevel, edges[start:end])
+		if err != nil {
+			b.Fatalf("write edge benchmark fragment: %v", err)
+		}
+		entry.Phase = PhaseEdges
+		entry.Path = path
+		files = append(files, entry)
+	}
+
+	value := newValidTestManifest(1)
+	value.Graphs = []GraphManifest{{
+		Name:      "benchmark",
+		NodeCount: nodeCount,
+		EdgeCount: edgeCount,
+		Files:     files,
+	}}
+
+	var compressedBytes int64
+	for _, fileEntry := range files {
+		compressedBytes += fileEntry.CompressedBytes
+	}
+	b.SetBytes(compressedBytes * 2)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if err := verifyLoadFragments(dir, value); err != nil {
+			b.Fatalf("preflight benchmark fragments: %v", err)
+		}
+
+		nodeMap := make(map[string]graph.ID, nodeCount)
+		var loadedNodes, loadedEdges int
+		for _, fileEntry := range files {
+			switch fileEntry.Phase {
+			case PhaseNodes:
+				if _, err := readNodeFragmentFile(dir, value.Compression, fileEntry, func(item FragmentNode) error {
+					loadedNodes++
+					nodeMap[item.ID] = graph.ID(loadedNodes)
+					return nil
+				}); err != nil {
+					b.Fatalf("load node benchmark fragment: %v", err)
+				}
+
+			case PhaseEdges:
+				if _, err := readEdgeFragmentFile(dir, value.Compression, fileEntry, func(item FragmentEdge) error {
+					if _, err := resolveFragmentEdge(item, nodeMap); err != nil {
+						return err
+					}
+					loadedEdges++
+					return nil
+				}); err != nil {
+					b.Fatalf("load edge benchmark fragment: %v", err)
+				}
+			}
+		}
+
+		if loadedNodes != nodeCount || loadedEdges != edgeCount {
+			b.Fatalf("unexpected benchmark counts: nodes=%d edges=%d", loadedNodes, loadedEdges)
+		}
+	}
+}

--- a/retriever/load_test.go
+++ b/retriever/load_test.go
@@ -2,7 +2,10 @@ package retriever
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -172,12 +175,9 @@ func TestReadLoadManifestRejectsNeo4jMultiGraph(t *testing.T) {
 
 func TestVerifyManifestFilesRejectsBadChecksum(t *testing.T) {
 	dir := t.TempDir()
-	entry, err := writeCompressedJSON(filepath.Join(dir, "fragment.gz"), CompressionGzip, DefaultZstdLevel, NodeFragment{
-		Phase: PhaseNodes,
-		Items: []FragmentNode{{
-			ID: "1",
-		}},
-	})
+	entry, err := writeCompressedJSONLines(filepath.Join(dir, "fragment.gz"), CompressionGzip, DefaultZstdLevel, []FragmentNode{{
+		ID: "1",
+	}})
 	if err != nil {
 		t.Fatalf("write fragment: %v", err)
 	}
@@ -214,83 +214,181 @@ func TestVerifyManifestFilesRejectsBadChecksum(t *testing.T) {
 
 func TestReadFragmentFilesValidatePhaseAndCount(t *testing.T) {
 	dir := t.TempDir()
-	nodeEntry, err := writeCompressedJSON(filepath.Join(dir, "nodes.gz"), CompressionGzip, DefaultZstdLevel, NodeFragment{
-		Phase: PhaseNodes,
-		Items: []FragmentNode{{
-			ID: "1",
-		}},
-	})
+	nodeEntry, err := writeCompressedJSONLines(filepath.Join(dir, "nodes.gz"), CompressionGzip, DefaultZstdLevel, []FragmentNode{{
+		ID: "1",
+	}})
 	if err != nil {
 		t.Fatalf("write node fragment: %v", err)
 	}
 
 	nodeFile := FileManifest{
+		Phase:           PhaseNodes,
 		Path:            "nodes.gz",
 		Count:           1,
 		CompressedBytes: nodeEntry.CompressedBytes,
 		SHA256:          nodeEntry.SHA256,
 	}
 
-	if fragment, err := readNodeFragmentFile(dir, CompressionGzip, nodeFile); err != nil {
+	var nodes []FragmentNode
+	if count, err := readNodeFragmentFile(dir, CompressionGzip, nodeFile, func(item FragmentNode) error {
+		nodes = append(nodes, item)
+
+		return nil
+	}); err != nil {
 		t.Fatalf("read node fragment: %v", err)
-	} else if len(fragment.Items) != 1 || fragment.Items[0].ID != "1" {
-		t.Fatalf("unexpected node fragment: %+v", fragment)
+	} else if count != 1 || len(nodes) != 1 || nodes[0].ID != "1" {
+		t.Fatalf("unexpected node records: %+v", nodes)
 	}
 
 	nodeFile.Count = 2
 
-	if _, err := readNodeFragmentFile(dir, CompressionGzip, nodeFile); err == nil {
+	if _, err := readNodeFragmentFile(dir, CompressionGzip, nodeFile, nil); err == nil {
 		t.Fatalf("expected node count mismatch")
 	}
 
-	wrongPhaseEntry, err := writeCompressedJSON(filepath.Join(dir, "wrong-Phase.gz"), CompressionGzip, DefaultZstdLevel, EdgeFragment{
-		Phase: PhaseEdges,
-		Items: []FragmentEdge{{
-			StartID: "1",
-			EndID:   "2",
-		}},
-	})
+	wrongPhaseEntry, err := writeCompressedJSONLines(filepath.Join(dir, "wrong-phase.gz"), CompressionGzip, DefaultZstdLevel, []FragmentEdge{{
+		StartID: "1",
+		EndID:   "2",
+	}})
 	if err != nil {
 		t.Fatalf("write wrong Phase fragment: %v", err)
 	}
 
 	if _, err := readNodeFragmentFile(dir, CompressionGzip, FileManifest{
-		Path:            "wrong-Phase.gz",
+		Phase:           PhaseEdges,
+		Path:            "wrong-phase.gz",
 		Count:           1,
 		CompressedBytes: wrongPhaseEntry.CompressedBytes,
 		SHA256:          wrongPhaseEntry.SHA256,
-	}); err == nil {
+	}, nil); err == nil {
 		t.Fatalf("expected node Phase mismatch")
-	} else if !strings.Contains(err.Error(), "Phase") {
+	} else if !strings.Contains(err.Error(), "phase") {
 		t.Fatalf("expected node Phase mismatch, got %v", err)
 	}
 
-	edgeEntry, err := writeCompressedJSON(filepath.Join(dir, "edges.gz"), CompressionGzip, DefaultZstdLevel, EdgeFragment{
-		Phase: PhaseEdges,
-		Items: []FragmentEdge{{
-			StartID: "1",
-			EndID:   "2",
-			Kind:    "AdminTo",
-		}},
-	})
+	edgeEntry, err := writeCompressedJSONLines(filepath.Join(dir, "edges.gz"), CompressionGzip, DefaultZstdLevel, []FragmentEdge{{
+		StartID: "1",
+		EndID:   "2",
+		Kind:    "AdminTo",
+	}})
 	if err != nil {
 		t.Fatalf("write edge fragment: %v", err)
 	}
 
 	edgeFile := FileManifest{
+		Phase:           PhaseEdges,
 		Path:            "edges.gz",
 		Count:           1,
 		CompressedBytes: edgeEntry.CompressedBytes,
 		SHA256:          edgeEntry.SHA256,
 	}
-	if fragment, err := readEdgeFragmentFile(dir, CompressionGzip, edgeFile); err != nil {
+	var edges []FragmentEdge
+	if count, err := readEdgeFragmentFile(dir, CompressionGzip, edgeFile, func(item FragmentEdge) error {
+		edges = append(edges, item)
+
+		return nil
+	}); err != nil {
 		t.Fatalf("read edge fragment: %v", err)
-	} else if len(fragment.Items) != 1 || fragment.Items[0].Kind != "AdminTo" {
-		t.Fatalf("unexpected edge fragment: %+v", fragment)
+	} else if count != 1 || len(edges) != 1 || edges[0].Kind != "AdminTo" {
+		t.Fatalf("unexpected edge records: %+v", edges)
 	}
 
 	edgeFile.Count = 2
-	if _, err := readEdgeFragmentFile(dir, CompressionGzip, edgeFile); err == nil {
+	if _, err := readEdgeFragmentFile(dir, CompressionGzip, edgeFile, nil); err == nil {
 		t.Fatalf("expected edge count mismatch")
+	}
+}
+
+func TestVerifyLoadFragmentsRejectsMalformedJSONLines(t *testing.T) {
+	dir := t.TempDir()
+	fragmentPath := filepath.Join(dir, "nodes.jsonl.gz")
+	writeCompressedPayload(t, fragmentPath, CompressionGzip, "{\"id\":\"1\",\"kinds\":[]}\n\n")
+
+	contents, err := os.ReadFile(fragmentPath)
+	if err != nil {
+		t.Fatalf("read fragment: %v", err)
+	}
+	checksum := sha256.Sum256(contents)
+
+	value := newValidTestManifest(1)
+	value.Graphs = []GraphManifest{{
+		Name:      "default",
+		NodeCount: 2,
+		Files: []FileManifest{{
+			Phase:           PhaseNodes,
+			Path:            "nodes.jsonl.gz",
+			Count:           2,
+			CompressedBytes: int64(len(contents)),
+			SHA256:          hex.EncodeToString(checksum[:]),
+		}},
+	}}
+
+	if err := verifyLoadFragments(dir, value); err == nil || !strings.Contains(err.Error(), "blank line") {
+		t.Fatalf("expected malformed JSONL preflight error, got %v", err)
+	}
+}
+
+func TestVerifyLoadFragmentsPrioritizesIntegrityFailure(t *testing.T) {
+	dir := t.TempDir()
+	fragmentPath := filepath.Join(dir, "nodes.jsonl.gz")
+	writeCompressedPayload(t, fragmentPath, CompressionGzip, "{\"id\":\"1\",\"kinds\":[]}\n\n")
+
+	contents, err := os.ReadFile(fragmentPath)
+	if err != nil {
+		t.Fatalf("read fragment: %v", err)
+	}
+
+	value := newValidTestManifest(1)
+	value.Graphs = []GraphManifest{{
+		Name:      "default",
+		NodeCount: 2,
+		Files: []FileManifest{{
+			Phase:           PhaseNodes,
+			Path:            "nodes.jsonl.gz",
+			Count:           2,
+			CompressedBytes: int64(len(contents)),
+			SHA256:          "bad",
+		}},
+	}}
+
+	err = verifyLoadFragments(dir, value)
+	var checksumErr ChecksumMismatchError
+	if !errors.As(err, &checksumErr) {
+		t.Fatalf("expected checksum error before malformed JSONL error, got %v", err)
+	}
+}
+
+func TestReadFragmentFilesRejectEmptySourceIDs(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := writeCompressedJSONLines(filepath.Join(dir, "node.jsonl.gz"), CompressionGzip, DefaultZstdLevel, []FragmentNode{{}}); err != nil {
+		t.Fatalf("write node fragment: %v", err)
+	}
+	if _, err := readNodeFragmentFile(dir, CompressionGzip, FileManifest{
+		Phase: PhaseNodes,
+		Path:  "node.jsonl.gz",
+		Count: 1,
+	}, nil); err == nil || !strings.Contains(err.Error(), "empty source ID") {
+		t.Fatalf("expected empty node source ID error, got %v", err)
+	}
+
+	for name, edge := range map[string]FragmentEdge{
+		"start": {EndID: "2"},
+		"end":   {StartID: "1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := name + ".jsonl.gz"
+			if _, err := writeCompressedJSONLines(filepath.Join(dir, path), CompressionGzip, DefaultZstdLevel, []FragmentEdge{edge}); err != nil {
+				t.Fatalf("write edge fragment: %v", err)
+			}
+
+			if _, err := readEdgeFragmentFile(dir, CompressionGzip, FileManifest{
+				Phase: PhaseEdges,
+				Path:  path,
+				Count: 1,
+			}, nil); err == nil || !strings.Contains(err.Error(), "empty "+name+" source ID") {
+				t.Fatalf("expected empty %s source ID error, got %v", name, err)
+			}
+		})
 	}
 }

--- a/retriever/manifest_test.go
+++ b/retriever/manifest_test.go
@@ -6,20 +6,19 @@ import (
 )
 
 func TestManifestValidateRejectsUnsupportedFormat(t *testing.T) {
-	value := newValidTestManifest(0)
-	value.Format = "future"
+	for _, format := range []string{
+		"future",
+		"retriever-opengraph-collection-v1",
+		"retrievr-opengraph-collection-v1",
+	} {
+		t.Run(format, func(t *testing.T) {
+			value := newValidTestManifest(0)
+			value.Format = format
 
-	if err := value.validate(); err == nil {
-		t.Fatalf("expected unsupported format error")
-	}
-}
-
-func TestManifestValidateAcceptsLegacyFormat(t *testing.T) {
-	value := newValidTestManifest(0)
-	value.Format = legacyManifestFormat
-
-	if err := value.validate(); err != nil {
-		t.Fatalf("validate legacy Manifest format: %v", err)
+			if err := value.validate(); err == nil {
+				t.Fatalf("expected unsupported format error")
+			}
+		})
 	}
 }
 
@@ -29,11 +28,11 @@ func TestPublicManifestHelpers(t *testing.T) {
 		t.Fatalf("validate manifest through public method: %v", err)
 	}
 
-	if !IsSupportedManifestFormat(manifestFormat) || !IsSupportedManifestFormat(legacyManifestFormat) {
-		t.Fatalf("expected public format helper to accept current and legacy formats")
+	if !IsSupportedManifestFormat(manifestFormat) {
+		t.Fatalf("expected public format helper to accept current format")
 	}
 
-	if IsSupportedManifestFormat("future") {
+	if IsSupportedManifestFormat("retriever-opengraph-collection-v1") || IsSupportedManifestFormat("retrievr-opengraph-collection-v1") || IsSupportedManifestFormat("future") {
 		t.Fatalf("expected unsupported format to be rejected")
 	}
 
@@ -56,13 +55,13 @@ func TestManifestValidateRequiresNodeFilesBeforeEdgeFiles(t *testing.T) {
 		Files: []FileManifest{
 			{
 				Phase:  PhaseEdges,
-				Path:   "graphs/default/edges-000001.ogfrag.gz",
+				Path:   "graphs/default/edges-000001.jsonl.gz",
 				Count:  1,
 				SHA256: "abc",
 			},
 			{
 				Phase:  PhaseNodes,
-				Path:   "graphs/default/nodes-000001.ogfrag.gz",
+				Path:   "graphs/default/nodes-000001.jsonl.gz",
 				Count:  1,
 				SHA256: "def",
 			},
@@ -77,7 +76,7 @@ func TestManifestValidateRequiresNodeFilesBeforeEdgeFiles(t *testing.T) {
 func TestManifestValidateRejectsMalformedGraphEntries(t *testing.T) {
 	validFile := FileManifest{
 		Phase:           PhaseNodes,
-		Path:            "graphs/default/nodes-000001.ogfrag.gz",
+		Path:            "graphs/default/nodes-000001.jsonl.gz",
 		Count:           1,
 		CompressedBytes: 10,
 		SHA256:          "abc",
@@ -194,7 +193,7 @@ func TestManifestValidateAcceptsMetrics(t *testing.T) {
 		EdgeCount: 0,
 		Files: []FileManifest{{
 			Phase:           PhaseNodes,
-			Path:            "graphs/default/nodes-000001.ogfrag.gz",
+			Path:            "graphs/default/nodes-000001.jsonl.gz",
 			Count:           1,
 			CompressedBytes: 1,
 			SHA256:          "abc",

--- a/retriever/types.go
+++ b/retriever/types.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	manifestFormat       = "retriever-opengraph-collection-v1"
-	legacyManifestFormat = "retrievr-opengraph-collection-v1"
-	idStrategy           = "source_database_id_string"
+	manifestFormat = "retriever-jsonl-collection-v1"
+	idStrategy     = "source_database_id_string"
 )
 
 type Phase string
@@ -93,20 +92,10 @@ type FileManifest struct {
 	ActionCounts      map[string]int `json:"action_counts"`
 }
 
-type NodeFragment struct {
-	Phase Phase          `json:"phase"`
-	Items []FragmentNode `json:"items"`
-}
-
 type FragmentNode struct {
 	ID         string         `json:"id"`
 	Kinds      []string       `json:"kinds"`
 	Properties map[string]any `json:"properties,omitempty"`
-}
-
-type EdgeFragment struct {
-	Phase Phase          `json:"phase"`
-	Items []FragmentEdge `json:"items"`
 }
 
 type FragmentEdge struct {
@@ -227,12 +216,7 @@ func (s Manifest) Validate() error {
 }
 
 func isSupportedManifestFormat(format string) bool {
-	switch format {
-	case manifestFormat, legacyManifestFormat:
-		return true
-	default:
-		return false
-	}
+	return format == manifestFormat
 }
 
 func IsSupportedManifestFormat(format string) bool {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly explain the change and its motivation. -->

Resolves: 

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection exports now use manifest-based, compressed JSONL fragments.
  * Loading validates fragment integrity, JSONL records, record counts, and graph schemas before writing data.
  * Encrypted archive loading applies the same validation as directory-based loading.

* **Documentation**
  * Updated Quick Start and collection format documentation with JSONL structure, validation behavior, file metadata, and testing guidance.

* **Tests**
  * Expanded round-trip coverage across supported backends, including restored properties, relationships, and topology.
  * Added validation coverage for malformed records, checksums, unsafe paths, and large fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->