### PR TITLE
fix: handle grave-escaped property names properly BED-8967

### DIFF
--- a/cypher/frontend/expression.go
+++ b/cypher/frontend/expression.go
@@ -424,5 +424,5 @@ func (s *NonArithmeticOperatorExpressionVisitor) EnterOC_PropertyKeyName(ctx *pa
 }
 
 func (s *NonArithmeticOperatorExpressionVisitor) ExitOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNameContext) {
-	s.PropertyKeyName = cypher.UnescapePropertyKeyName(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
+	s.PropertyKeyName = extractPropertyKeyName(s.ctx, ctx)
 }

--- a/cypher/frontend/expression.go
+++ b/cypher/frontend/expression.go
@@ -424,5 +424,5 @@ func (s *NonArithmeticOperatorExpressionVisitor) EnterOC_PropertyKeyName(ctx *pa
 }
 
 func (s *NonArithmeticOperatorExpressionVisitor) ExitOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNameContext) {
-	s.PropertyKeyName = s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name
+	s.PropertyKeyName = cypher.UnescapePropertyKeyName(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
 }

--- a/cypher/frontend/literal.go
+++ b/cypher/frontend/literal.go
@@ -45,7 +45,7 @@ func (s *MapLiteralVisitor) EnterOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNa
 }
 
 func (s *MapLiteralVisitor) ExitOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNameContext) {
-	s.nextPropertyKey = s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name
+	s.nextPropertyKey = cypher.UnescapePropertyKeyName(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
 }
 
 func (s *MapLiteralVisitor) EnterOC_Expression(ctx *parser.OC_ExpressionContext) {

--- a/cypher/frontend/property_key.go
+++ b/cypher/frontend/property_key.go
@@ -1,0 +1,20 @@
+package frontend
+
+import (
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/parser"
+)
+
+func extractPropertyKeyName(ctx *Context, cypherCtx *parser.OC_PropertyKeyNameContext) string {
+	name := cypher.UnescapePropertyKeyName(ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
+	if err := cypher.ValidatePropertyKeyName(name); err != nil {
+		ctx.AddErrors(SyntaxError{
+			Line:            cypherCtx.GetStart().GetLine(),
+			Column:          cypherCtx.GetStart().GetColumn(),
+			OffendingSymbol: cypherCtx.GetText(),
+			Message:         err.Error(),
+		})
+	}
+
+	return name
+}

--- a/cypher/frontend/property_key_test.go
+++ b/cypher/frontend/property_key_test.go
@@ -24,6 +24,21 @@ func TestParsePropertyLookupStoresRawPropertyKeyNames(t *testing.T) {
 	require.Equal(t, []string{"match", "a-aaa", "has`tick", ""}, symbols)
 }
 
+func TestParsePropertyLookupStoresUnicodePropertyKeyNames(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN n.\u2118, n.a\u00b7, n.a\u0301, n.a\u093e, n.a$, n.`a\u20dd`")
+	require.NoError(t, err)
+
+	var symbols []string
+	err = walk.CypherStructural(regularQuery, walk.NewSimpleVisitor[cypher.SyntaxNode](func(node cypher.SyntaxNode, _ walk.VisitorHandler) {
+		if propertyLookup, typeOK := node.(*cypher.PropertyLookup); typeOK {
+			symbols = append(symbols, propertyLookup.Symbol)
+		}
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"\u2118", "a\u00b7", "a\u0301", "a\u093e", "a$", "a\u20dd"}, symbols)
+}
+
 func TestParseMapLiteralStoresRawPropertyKeyNames(t *testing.T) {
 	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN {match: 1, `a-aaa`: 2, `has``tick`: 3, ``: 4}")
 	require.NoError(t, err)

--- a/cypher/frontend/property_key_test.go
+++ b/cypher/frontend/property_key_test.go
@@ -1,0 +1,40 @@
+package frontend_test
+
+import (
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/walk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePropertyLookupStoresRawPropertyKeyNames(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN n.match, n.`a-aaa`, n.`has``tick`, n.``")
+	require.NoError(t, err)
+
+	var symbols []string
+	err = walk.CypherStructural(regularQuery, walk.NewSimpleVisitor[cypher.SyntaxNode](func(node cypher.SyntaxNode, _ walk.VisitorHandler) {
+		if propertyLookup, typeOK := node.(*cypher.PropertyLookup); typeOK {
+			symbols = append(symbols, propertyLookup.Symbol)
+		}
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"match", "a-aaa", "has`tick", ""}, symbols)
+}
+
+func TestParseMapLiteralStoresRawPropertyKeyNames(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN {match: 1, `a-aaa`: 2, `has``tick`: 3, ``: 4}")
+	require.NoError(t, err)
+
+	var keys []string
+	err = walk.CypherStructural(regularQuery, walk.NewSimpleVisitor[cypher.SyntaxNode](func(node cypher.SyntaxNode, _ walk.VisitorHandler) {
+		if mapItem, typeOK := node.(*cypher.MapItem); typeOK {
+			keys = append(keys, mapItem.Key)
+		}
+	}))
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{"match", "a-aaa", "has`tick", ""}, keys)
+}

--- a/cypher/frontend/property_key_test.go
+++ b/cypher/frontend/property_key_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestParsePropertyLookupStoresRawPropertyKeyNames(t *testing.T) {
-	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN n.match, n.`a-aaa`, n.`has``tick`, n.``")
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN n.match, n.`a-aaa`, n.`has``tick`, n.`   `")
 	require.NoError(t, err)
 
 	var symbols []string
@@ -21,7 +21,7 @@ func TestParsePropertyLookupStoresRawPropertyKeyNames(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"match", "a-aaa", "has`tick", ""}, symbols)
+	require.Equal(t, []string{"match", "a-aaa", "has`tick", "   "}, symbols)
 }
 
 func TestParsePropertyLookupStoresUnicodePropertyKeyNames(t *testing.T) {
@@ -40,7 +40,7 @@ func TestParsePropertyLookupStoresUnicodePropertyKeyNames(t *testing.T) {
 }
 
 func TestParseMapLiteralStoresRawPropertyKeyNames(t *testing.T) {
-	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN {match: 1, `a-aaa`: 2, `has``tick`: 3, ``: 4}")
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN {match: 1, `a-aaa`: 2, `has``tick`: 3, ``: 4, `   `: 5}")
 	require.NoError(t, err)
 
 	var keys []string
@@ -51,5 +51,23 @@ func TestParseMapLiteralStoresRawPropertyKeyNames(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	require.ElementsMatch(t, []string{"match", "a-aaa", "has`tick", ""}, keys)
+	require.ElementsMatch(t, []string{"match", "a-aaa", "has`tick", "", "   "}, keys)
+}
+
+func TestParseRejectsEmptyPropertyKeyNames(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{name: "property lookup", query: "RETURN n.``"},
+		{name: "set property", query: "MATCH (n) SET n.`` = 'value'"},
+		{name: "remove property", query: "MATCH (n) REMOVE n.``"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := frontend.ParseCypher(frontend.NewContext(), testCase.query)
+			require.ErrorContains(t, err, cypher.ErrEmptyPropertyKeyName.Error())
+		})
+	}
 }

--- a/cypher/frontend/property_key_test.go
+++ b/cypher/frontend/property_key_test.go
@@ -24,6 +24,21 @@ func TestParsePropertyLookupStoresRawPropertyKeyNames(t *testing.T) {
 	require.Equal(t, []string{"match", "a-aaa", "has`tick", "   "}, symbols)
 }
 
+func TestParsePropertyLookupStoresQuotePropertyKeyNames(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN n.`'`, n.`\"`")
+	require.NoError(t, err)
+
+	var symbols []string
+	err = walk.CypherStructural(regularQuery, walk.NewSimpleVisitor[cypher.SyntaxNode](func(node cypher.SyntaxNode, _ walk.VisitorHandler) {
+		if propertyLookup, typeOK := node.(*cypher.PropertyLookup); typeOK {
+			symbols = append(symbols, propertyLookup.Symbol)
+		}
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"'", "\""}, symbols)
+}
+
 func TestParsePropertyLookupStoresUnicodePropertyKeyNames(t *testing.T) {
 	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN n.\u2118, n.a\u00b7, n.a\u0301, n.a\u093e, n.a$, n.`a\u20dd`")
 	require.NoError(t, err)
@@ -52,6 +67,21 @@ func TestParseMapLiteralStoresRawPropertyKeyNames(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, []string{"match", "a-aaa", "has`tick", "", "   "}, keys)
+}
+
+func TestParseMapLiteralStoresQuotePropertyKeyNames(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "RETURN {`'`: 1, `\"`: 2}")
+	require.NoError(t, err)
+
+	var keys []string
+	err = walk.CypherStructural(regularQuery, walk.NewSimpleVisitor[cypher.SyntaxNode](func(node cypher.SyntaxNode, _ walk.VisitorHandler) {
+		if mapItem, typeOK := node.(*cypher.MapItem); typeOK {
+			keys = append(keys, mapItem.Key)
+		}
+	}))
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{"'", "\""}, keys)
 }
 
 func TestParseRejectsEmptyPropertyKeyNames(t *testing.T) {

--- a/cypher/frontend/query.go
+++ b/cypher/frontend/query.go
@@ -707,5 +707,5 @@ func (s *PropertyExpressionVisitor) EnterOC_PropertyKeyName(ctx *parser.OC_Prope
 }
 
 func (s *PropertyExpressionVisitor) ExitOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNameContext) {
-	s.PropertyLookup.SetSymbol(cypher.UnescapePropertyKeyName(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name))
+	s.PropertyLookup.SetSymbol(extractPropertyKeyName(s.ctx, ctx))
 }

--- a/cypher/frontend/query.go
+++ b/cypher/frontend/query.go
@@ -707,5 +707,5 @@ func (s *PropertyExpressionVisitor) EnterOC_PropertyKeyName(ctx *parser.OC_Prope
 }
 
 func (s *PropertyExpressionVisitor) ExitOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNameContext) {
-	s.PropertyLookup.SetSymbol(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
+	s.PropertyLookup.SetSymbol(cypher.UnescapePropertyKeyName(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name))
 }

--- a/cypher/models/cypher/format/format.go
+++ b/cypher/models/cypher/format/format.go
@@ -633,6 +633,10 @@ func (s Emitter) WriteExpression(output io.Writer, expression cypher.Expression)
 			return err
 		}
 
+		if err := cypher.ValidatePropertyKeyName(typedExpression.Symbol); err != nil {
+			return err
+		}
+
 		if _, err := io.WriteString(output, cypher.EscapePropertyKeyName(typedExpression.Symbol)); err != nil {
 			return err
 		}

--- a/cypher/models/cypher/format/format.go
+++ b/cypher/models/cypher/format/format.go
@@ -332,7 +332,7 @@ func (s Emitter) formatMapLiteral(output io.Writer, mapLiteral cypher.MapLiteral
 			first = false
 		}
 
-		if _, err := io.WriteString(output, key); err != nil {
+		if _, err := io.WriteString(output, cypher.EscapePropertyKeyName(key)); err != nil {
 			return err
 		}
 
@@ -633,7 +633,7 @@ func (s Emitter) WriteExpression(output io.Writer, expression cypher.Expression)
 			return err
 		}
 
-		if _, err := io.WriteString(output, typedExpression.Symbol); err != nil {
+		if _, err := io.WriteString(output, cypher.EscapePropertyKeyName(typedExpression.Symbol)); err != nil {
 			return err
 		}
 

--- a/cypher/models/cypher/format/format_test.go
+++ b/cypher/models/cypher/format/format_test.go
@@ -56,10 +56,11 @@ func TestCypherEmitter_FormatsMapLiteralPropertyKeys(t *testing.T) {
 		"has`tick": cypher.NewLiteral(3, false),
 		"":         cypher.NewLiteral(4, false),
 		"   ":      cypher.NewLiteral(5, false),
+		"'":        cypher.NewLiteral(6, false),
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, "{``: 4, `   `: 5, `a-aaa`: 2, `has``tick`: 3, match: 1}", buffer.String())
+	require.Equal(t, "{``: 4, `   `: 5, `'`: 6, `a-aaa`: 2, `has``tick`: 3, match: 1}", buffer.String())
 }
 
 func TestCypherEmitter_FormatsPropertyLookupKeys(t *testing.T) {
@@ -87,6 +88,11 @@ func TestCypherEmitter_FormatsPropertyLookupKeys(t *testing.T) {
 			name:     "key with backtick",
 			symbol:   "has`tick",
 			expected: "n.`has``tick`",
+		},
+		{
+			name:     "key with single quote",
+			symbol:   "'",
+			expected: "n.`'`",
 		},
 		{
 			name:     "whitespace-only key",

--- a/cypher/models/cypher/format/format_test.go
+++ b/cypher/models/cypher/format/format_test.go
@@ -44,6 +44,72 @@ func TestCypherEmitter_FormatsMapLiteralInKeyOrder(t *testing.T) {
 	require.Equal(t, "{a: 1, b: 2}", buffer.String())
 }
 
+func TestCypherEmitter_FormatsMapLiteralPropertyKeys(t *testing.T) {
+	var (
+		buffer  = &bytes.Buffer{}
+		emitter = format.NewCypherEmitter(false)
+	)
+
+	err := emitter.WriteExpression(buffer, cypher.MapLiteral{
+		"match":    cypher.NewLiteral(1, false),
+		"a-aaa":    cypher.NewLiteral(2, false),
+		"has`tick": cypher.NewLiteral(3, false),
+		"":         cypher.NewLiteral(4, false),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "{``: 4, `a-aaa`: 2, `has``tick`: 3, match: 1}", buffer.String())
+}
+
+func TestCypherEmitter_FormatsPropertyLookupKeys(t *testing.T) {
+	testCases := []struct {
+		name     string
+		symbol   string
+		expected string
+	}{
+		{
+			name:     "simple key",
+			symbol:   "name",
+			expected: "n.name",
+		},
+		{
+			name:     "reserved word key",
+			symbol:   "match",
+			expected: "n.match",
+		},
+		{
+			name:     "key with hyphen",
+			symbol:   "a-aaa",
+			expected: "n.`a-aaa`",
+		},
+		{
+			name:     "key with backtick",
+			symbol:   "has`tick",
+			expected: "n.`has``tick`",
+		},
+		{
+			name:     "empty key",
+			symbol:   "",
+			expected: "n.``",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			emitter := format.NewCypherEmitter(false)
+
+			err := emitter.WriteExpression(buffer, &cypher.PropertyLookup{
+				Atom:   cypher.NewVariableWithSymbol("n"),
+				Symbol: testCase.symbol,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, buffer.String())
+		})
+	}
+}
+
 func TestCypherEmitter_MapLiteralPropagatesExpressionError(t *testing.T) {
 	var (
 		buffer  = &bytes.Buffer{}

--- a/cypher/models/cypher/format/format_test.go
+++ b/cypher/models/cypher/format/format_test.go
@@ -55,10 +55,11 @@ func TestCypherEmitter_FormatsMapLiteralPropertyKeys(t *testing.T) {
 		"a-aaa":    cypher.NewLiteral(2, false),
 		"has`tick": cypher.NewLiteral(3, false),
 		"":         cypher.NewLiteral(4, false),
+		"   ":      cypher.NewLiteral(5, false),
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, "{``: 4, `a-aaa`: 2, `has``tick`: 3, match: 1}", buffer.String())
+	require.Equal(t, "{``: 4, `   `: 5, `a-aaa`: 2, `has``tick`: 3, match: 1}", buffer.String())
 }
 
 func TestCypherEmitter_FormatsPropertyLookupKeys(t *testing.T) {
@@ -88,9 +89,9 @@ func TestCypherEmitter_FormatsPropertyLookupKeys(t *testing.T) {
 			expected: "n.`has``tick`",
 		},
 		{
-			name:     "empty key",
-			symbol:   "",
-			expected: "n.``",
+			name:     "whitespace-only key",
+			symbol:   "   ",
+			expected: "n.`   `",
 		},
 	}
 
@@ -108,6 +109,18 @@ func TestCypherEmitter_FormatsPropertyLookupKeys(t *testing.T) {
 			require.Equal(t, testCase.expected, buffer.String())
 		})
 	}
+}
+
+func TestCypherEmitter_RejectsEmptyPropertyLookupKey(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	emitter := format.NewCypherEmitter(false)
+
+	err := emitter.WriteExpression(buffer, &cypher.PropertyLookup{
+		Atom:   cypher.NewVariableWithSymbol("n"),
+		Symbol: "",
+	})
+
+	require.ErrorIs(t, err, cypher.ErrEmptyPropertyKeyName)
 }
 
 func TestCypherEmitter_MapLiteralPropagatesExpressionError(t *testing.T) {

--- a/cypher/models/cypher/model.go
+++ b/cypher/models/cypher/model.go
@@ -1307,7 +1307,10 @@ func (s *ProjectionItem) copy() *ProjectionItem {
 }
 
 type PropertyLookup struct {
-	Atom   Expression
+	Atom Expression
+
+	// Symbol is the raw property key, not an already-rendered Cypher token.
+	// Callers should not pre-wrap names in backticks; formatting handles that.
 	Symbol string
 }
 

--- a/cypher/models/cypher/property_key.go
+++ b/cypher/models/cypher/property_key.go
@@ -5,12 +5,20 @@ import (
 	"unicode"
 )
 
+func isCypherIDStart(char rune) bool {
+	return unicode.IsLetter(char) || unicode.In(char, unicode.Nl, unicode.Other_ID_Start)
+}
+
+func isCypherIDContinue(char rune) bool {
+	return isCypherIDStart(char) || unicode.In(char, unicode.Mn, unicode.Mc, unicode.Nd, unicode.Pc, unicode.Other_ID_Continue)
+}
+
 func isCypherSymbolStart(char rune) bool {
-	return char == '_' || unicode.IsLetter(char) || unicode.In(char, unicode.Nl, unicode.Pc)
+	return isCypherIDStart(char) || unicode.In(char, unicode.Pc)
 }
 
 func isCypherSymbolPart(char rune) bool {
-	return isCypherSymbolStart(char) || unicode.IsDigit(char) || unicode.In(char, unicode.Mark, unicode.Sc)
+	return isCypherIDContinue(char) || unicode.In(char, unicode.Sc)
 }
 
 // CanEmitBarePropertyKeyName returns true when a raw property key can be emitted without backticks.

--- a/cypher/models/cypher/property_key.go
+++ b/cypher/models/cypher/property_key.go
@@ -1,0 +1,61 @@
+package cypher
+
+import (
+	"strings"
+	"unicode"
+)
+
+func isCypherSymbolStart(char rune) bool {
+	return char == '_' || unicode.IsLetter(char) || unicode.In(char, unicode.Nl, unicode.Pc)
+}
+
+func isCypherSymbolPart(char rune) bool {
+	return isCypherSymbolStart(char) || unicode.IsDigit(char) || unicode.In(char, unicode.Mark, unicode.Sc)
+}
+
+// CanEmitBarePropertyKeyName returns true when a raw property key can be emitted without backticks.
+//
+// This is specific to Cypher property-key position, such as n.name and {name: value}. Property keys use
+// oC_PropertyKeyName -> oC_SchemaName, where reserved words are valid bare names, unlike variable or parameter
+// symbols. Empty keys and keys containing characters outside the unescaped symbolic-name grammar return false; they
+// are still representable by EscapePropertyKeyName using backticks.
+func CanEmitBarePropertyKeyName(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	for idx, char := range name {
+		if idx == 0 {
+			if !isCypherSymbolStart(char) {
+				return false
+			}
+		} else if !isCypherSymbolPart(char) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// EscapePropertyKeyName formats a raw property key as a Cypher property-key token.
+func EscapePropertyKeyName(name string) string {
+	if CanEmitBarePropertyKeyName(name) {
+		return name
+	}
+
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// IsEscapedPropertyKeyName returns true when name is wrapped in Cypher backtick delimiters.
+func IsEscapedPropertyKeyName(name string) bool {
+	return len(name) >= 2 && name[0] == '`' && name[len(name)-1] == '`'
+}
+
+// UnescapePropertyKeyName decodes a Cypher property-key token into the raw property key it names.
+func UnescapePropertyKeyName(name string) string {
+	if !IsEscapedPropertyKeyName(name) {
+		return name
+	}
+
+	return strings.ReplaceAll(name[1:len(name)-1], "``", "`")
+}

--- a/cypher/models/cypher/property_key.go
+++ b/cypher/models/cypher/property_key.go
@@ -1,9 +1,12 @@
 package cypher
 
 import (
+	"errors"
 	"strings"
 	"unicode"
 )
+
+var ErrEmptyPropertyKeyName = errors.New("property key name must not be empty")
 
 func isCypherIDStart(char rune) bool {
 	return unicode.IsLetter(char) || unicode.In(char, unicode.Nl, unicode.Other_ID_Start)
@@ -25,8 +28,8 @@ func isCypherSymbolPart(char rune) bool {
 //
 // This is specific to Cypher property-key position, such as n.name and {name: value}. Property keys use
 // oC_PropertyKeyName -> oC_SchemaName, where reserved words are valid bare names, unlike variable or parameter
-// symbols. Empty keys and keys containing characters outside the unescaped symbolic-name grammar return false; they
-// are still representable by EscapePropertyKeyName using backticks.
+// symbols. Empty keys and keys containing characters outside the unescaped symbolic-name grammar return false; non-empty
+// keys outside the bare grammar are still representable by EscapePropertyKeyName using backticks.
 func CanEmitBarePropertyKeyName(name string) bool {
 	if name == "" {
 		return false
@@ -43,6 +46,14 @@ func CanEmitBarePropertyKeyName(name string) bool {
 	}
 
 	return true
+}
+
+func ValidatePropertyKeyName(name string) error {
+	if name == "" {
+		return ErrEmptyPropertyKeyName
+	}
+
+	return nil
 }
 
 // EscapePropertyKeyName formats a raw property key as a Cypher property-key token.

--- a/cypher/models/cypher/property_key_test.go
+++ b/cypher/models/cypher/property_key_test.go
@@ -55,6 +55,8 @@ func TestEscapePropertyKeyName(t *testing.T) {
 		{name: "starts backtick", input: "`starts-tick", expected: "```starts-tick`"},
 		{name: "wrapped backticks", input: "`super-wrapped`", expected: "```super-wrapped```"},
 		{name: "single backtick", input: "`", expected: "````"},
+		{name: "single quote", input: "'", expected: "`'`"},
+		{name: "double quote", input: "\"", expected: "`\"`"},
 		{name: "whitespace-only", input: "   ", expected: "`   `"},
 	}
 
@@ -82,6 +84,8 @@ func TestUnescapePropertyKeyName(t *testing.T) {
 		{name: "starts backtick", input: "```starts-tick`", expected: "`starts-tick"},
 		{name: "wrapped backticks", input: "```super-wrapped```", expected: "`super-wrapped`"},
 		{name: "single backtick", input: "````", expected: "`"},
+		{name: "single quote", input: "`'`", expected: "'"},
+		{name: "double quote", input: "`\"`", expected: "\""},
 		{name: "empty", input: "``", expected: ""},
 	}
 

--- a/cypher/models/cypher/property_key_test.go
+++ b/cypher/models/cypher/property_key_test.go
@@ -1,0 +1,75 @@
+package cypher_test
+
+import (
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanEmitBarePropertyKeyName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{name: "simple", input: "name", expected: true},
+		{name: "underscore", input: "object_id", expected: true},
+		{name: "reserved word allowed in property key position", input: "match", expected: true},
+		{name: "empty", input: "", expected: false},
+		{name: "dash", input: "a-aaa", expected: false},
+		{name: "starts digit", input: "1name", expected: false},
+		{name: "literal backtick", input: "has`tick", expected: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, cypher.CanEmitBarePropertyKeyName(testCase.input))
+		})
+	}
+}
+
+func TestEscapePropertyKeyName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "simple", input: "name", expected: "name"},
+		{name: "reserved word allowed in property key position", input: "match", expected: "match"},
+		{name: "dash", input: "a-aaa", expected: "`a-aaa`"},
+		{name: "embedded backtick", input: "has`tick", expected: "`has``tick`"},
+		{name: "starts backtick", input: "`starts-tick", expected: "```starts-tick`"},
+		{name: "wrapped backticks", input: "`super-wrapped`", expected: "```super-wrapped```"},
+		{name: "single backtick", input: "`", expected: "````"},
+		{name: "empty", input: "", expected: "``"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, cypher.EscapePropertyKeyName(testCase.input))
+		})
+	}
+}
+
+func TestUnescapePropertyKeyName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "simple", input: "name", expected: "name"},
+		{name: "dash", input: "`a-aaa`", expected: "a-aaa"},
+		{name: "embedded backtick", input: "`has``tick`", expected: "has`tick"},
+		{name: "starts backtick", input: "```starts-tick`", expected: "`starts-tick"},
+		{name: "wrapped backticks", input: "```super-wrapped```", expected: "`super-wrapped`"},
+		{name: "single backtick", input: "````", expected: "`"},
+		{name: "empty", input: "``", expected: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, cypher.UnescapePropertyKeyName(testCase.input))
+		})
+	}
+}

--- a/cypher/models/cypher/property_key_test.go
+++ b/cypher/models/cypher/property_key_test.go
@@ -16,10 +16,17 @@ func TestCanEmitBarePropertyKeyName(t *testing.T) {
 		{name: "simple", input: "name", expected: true},
 		{name: "underscore", input: "object_id", expected: true},
 		{name: "reserved word allowed in property key position", input: "match", expected: true},
+		{name: "other id start", input: "\u2118", expected: true},
+		{name: "other id continue", input: "a\u00b7", expected: true},
+		{name: "nonspacing mark part", input: "a\u0301", expected: true},
+		{name: "spacing mark part", input: "a\u093e", expected: true},
+		{name: "currency symbol part", input: "a$", expected: true},
 		{name: "empty", input: "", expected: false},
 		{name: "dash", input: "a-aaa", expected: false},
 		{name: "starts digit", input: "1name", expected: false},
+		{name: "starts currency symbol", input: "$a", expected: false},
 		{name: "literal backtick", input: "has`tick", expected: false},
+		{name: "enclosing mark part", input: "a\u20dd", expected: false},
 	}
 
 	for _, testCase := range testCases {
@@ -37,6 +44,12 @@ func TestEscapePropertyKeyName(t *testing.T) {
 	}{
 		{name: "simple", input: "name", expected: "name"},
 		{name: "reserved word allowed in property key position", input: "match", expected: "match"},
+		{name: "other id start", input: "\u2118", expected: "\u2118"},
+		{name: "other id continue", input: "a\u00b7", expected: "a\u00b7"},
+		{name: "nonspacing mark part", input: "a\u0301", expected: "a\u0301"},
+		{name: "spacing mark part", input: "a\u093e", expected: "a\u093e"},
+		{name: "currency symbol part", input: "a$", expected: "a$"},
+		{name: "enclosing mark part", input: "a\u20dd", expected: "`a\u20dd`"},
 		{name: "dash", input: "a-aaa", expected: "`a-aaa`"},
 		{name: "embedded backtick", input: "has`tick", expected: "`has``tick`"},
 		{name: "starts backtick", input: "`starts-tick", expected: "```starts-tick`"},

--- a/cypher/models/cypher/property_key_test.go
+++ b/cypher/models/cypher/property_key_test.go
@@ -55,7 +55,7 @@ func TestEscapePropertyKeyName(t *testing.T) {
 		{name: "starts backtick", input: "`starts-tick", expected: "```starts-tick`"},
 		{name: "wrapped backticks", input: "`super-wrapped`", expected: "```super-wrapped```"},
 		{name: "single backtick", input: "`", expected: "````"},
-		{name: "empty", input: "", expected: "``"},
+		{name: "whitespace-only", input: "   ", expected: "`   `"},
 	}
 
 	for _, testCase := range testCases {
@@ -63,6 +63,11 @@ func TestEscapePropertyKeyName(t *testing.T) {
 			require.Equal(t, testCase.expected, cypher.EscapePropertyKeyName(testCase.input))
 		})
 	}
+}
+
+func TestValidatePropertyKeyName(t *testing.T) {
+	require.NoError(t, cypher.ValidatePropertyKeyName("   "))
+	require.ErrorIs(t, cypher.ValidatePropertyKeyName(""), cypher.ErrEmptyPropertyKeyName)
 }
 
 func TestUnescapePropertyKeyName(t *testing.T) {

--- a/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -47,6 +47,27 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from
 -- case: match (n) where n.name = '1234' return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> 'name')) = 'string' and (n0.properties ->> 'name') = '1234'))) select s0.n0 as n from s0;
 
+-- case: match (n) where n.`a-aaa` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> 'a-aaa')) = 'string' and (n0.properties ->> 'a-aaa') = '123'))) select s0.n0 as n from s0;
+
+-- case: match (n) where n.`b_bbb` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> 'b_bbb')) = 'string' and (n0.properties ->> 'b_bbb') = '123'))) select s0.n0 as n from s0;
+
+-- case: match (n) where n.`has``tick` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> 'has`tick')) = 'string' and (n0.properties ->> 'has`tick') = '123'))) select s0.n0 as n from s0;
+
+-- case: match (n) where n.```starts-tick` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> '`starts-tick')) = 'string' and (n0.properties ->> '`starts-tick') = '123'))) select s0.n0 as n from s0;
+
+-- case: match (n) where n.```super-wrapped``` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> '`super-wrapped`')) = 'string' and (n0.properties ->> '`super-wrapped`') = '123'))) select s0.n0 as n from s0;
+
+-- case: match (n) where n.```` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> '`')) = 'string' and (n0.properties ->> '`') = '123'))) select s0.n0 as n from s0;
+
+-- case: match (n) where (n).`a-aaa` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s0.n0 as n from s0 where ((jsonb_typeof((((s0.n0)).properties -> 'a-aaa')) = 'string' and (((s0.n0)).properties ->> 'a-aaa') = '123'));
+
 -- case: match (n:NodeKind1 {name: "SOME NAME"}) return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where n0.kind_ids operator (pg_catalog.@>) array [1]::int2[] and (jsonb_typeof((n0.properties -> 'name')) = 'string' and (n0.properties ->> 'name') = 'SOME NAME')) select s0.n0 as n from s0;
 

--- a/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -68,6 +68,9 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from
 -- case: match (n) where (n).`a-aaa` = "123" return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s0.n0 as n from s0 where ((jsonb_typeof((((s0.n0)).properties -> 'a-aaa')) = 'string' and (((s0.n0)).properties ->> 'a-aaa') = '123'));
 
+-- case: match ()-[r]-() where startNode(r).`something` = "abc" return r
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s0.n0 as n from s0 where ((jsonb_typeof(((start_node(s0.n0)::nodecomposite).properties -> 'something')) = 'string' and ((start_node(s0.n0)::nodecomposite).properties ->> 'something') = 'abc'));
+
 -- case: match (n:NodeKind1 {name: "SOME NAME"}) return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where n0.kind_ids operator (pg_catalog.@>) array [1]::int2[] and (jsonb_typeof((n0.properties -> 'name')) = 'string' and (n0.properties ->> 'name') = 'SOME NAME')) select s0.n0 as n from s0;
 

--- a/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -56,6 +56,9 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from
 -- case: match (n) where n.`has``tick` = "123" return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> 'has`tick')) = 'string' and (n0.properties ->> 'has`tick') = '123'))) select s0.n0 as n from s0;
 
+-- case: match (n) where n.`'` = "123" return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> '''')) = 'string' and (n0.properties ->> '''') = '123'))) select s0.n0 as n from s0;
+
 -- case: match (n) where n.```starts-tick` = "123" return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where ((jsonb_typeof((n0.properties -> '`starts-tick')) = 'string' and (n0.properties ->> '`starts-tick') = '123'))) select s0.n0 as n from s0;
 
@@ -73,6 +76,9 @@ with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::e
 
 -- case: match (n:NodeKind1 {name: "SOME NAME"}) return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where n0.kind_ids operator (pg_catalog.@>) array [1]::int2[] and (jsonb_typeof((n0.properties -> 'name')) = 'string' and (n0.properties ->> 'name') = 'SOME NAME')) select s0.n0 as n from s0;
+
+-- case: match (n:NodeKind1 {`'`: 'value'}) return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where n0.kind_ids operator (pg_catalog.@>) array [1]::int2[] and (jsonb_typeof((n0.properties -> '''')) = 'string' and (n0.properties ->> '''') = 'value')) select s0.n0 as n from s0;
 
 -- case: match (n) where n.objectid in $p return n
 -- cypher_params: {"p":["1","2","3"]}

--- a/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -69,7 +69,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s0.n0 as n from s0 where ((jsonb_typeof((((s0.n0)).properties -> 'a-aaa')) = 'string' and (((s0.n0)).properties ->> 'a-aaa') = '123'));
 
 -- case: match ()-[r]-() where startNode(r).`something` = "abc" return r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0) select s0.n0 as n from s0 where ((jsonb_typeof(((start_node(s0.n0)::nodecomposite).properties -> 'something')) = 'string' and ((start_node(s0.n0)::nodecomposite).properties ->> 'something') = 'abc'));
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0 from edge e0 join node n0 on (n0.id = e0.end_id or n0.id = e0.start_id) join node n1 on (n1.id = e0.end_id or n1.id = e0.start_id) where (n0.id <> n1.id)) select s0.e0 as r from s0 where ((jsonb_typeof(((start_node(((s0.e0).id, (s0.e0).start_id, (s0.e0).end_id, (s0.e0).kind_id, (s0.e0).properties)::edgecomposite)::nodecomposite).properties -> 'something')) = 'string' and ((start_node(((s0.e0).id, (s0.e0).start_id, (s0.e0).end_id, (s0.e0).kind_id, (s0.e0).properties)::edgecomposite)::nodecomposite).properties ->> 'something') = 'abc'));
 
 -- case: match (n:NodeKind1 {name: "SOME NAME"}) return n
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0 where n0.kind_ids operator (pg_catalog.@>) array [1]::int2[] and (jsonb_typeof((n0.properties -> 'name')) = 'string' and (n0.properties ->> 'name') = 'SOME NAME')) select s0.n0 as n from s0;

--- a/cypher/models/pgsql/translate/expression.go
+++ b/cypher/models/pgsql/translate/expression.go
@@ -54,6 +54,20 @@ func (s *Translator) translateCompositePropertyLookup(target pgsql.Expression, l
 	}
 }
 
+func isEscapedPropertyLookupName(literal pgsql.Literal) bool {
+	if litString, typeOK := literal.Value.(string); !typeOK {
+		return false
+	} else if len(litString) > 2 && litString[0] == '`' && litString[len(litString)-1] == '`' {
+		return true
+	}
+
+	return false
+}
+
+func unescapePropertyLookupName(name string) string {
+	return strings.ReplaceAll(name[1:len(name)-1], "``", "`")
+}
+
 func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) error {
 	if translatedAtom, err := s.treeTranslator.PopOperand(); err != nil {
 		return err
@@ -64,7 +78,13 @@ func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) erro
 				return err
 			} else {
 				s.treeTranslator.PushOperand(pgsql.CompoundIdentifier{typedTranslatedAtom, pgsql.ColumnProperties})
-				s.treeTranslator.PushOperand(fieldIdentifierLiteral)
+				if !isEscapedPropertyLookupName(fieldIdentifierLiteral) {
+					s.treeTranslator.PushOperand(fieldIdentifierLiteral)
+				} else if unescapedLiteral, err := pgsql.AsLiteral(unescapePropertyLookupName(fieldIdentifierLiteral.Value.(string))); err != nil {
+					return err
+				} else {
+					s.treeTranslator.PushOperand(unescapedLiteral)
+				}
 
 				if err := s.treeTranslator.CompleteBinaryExpression(s.scope, pgsql.OperatorPropertyLookup); err != nil {
 					return err
@@ -83,7 +103,13 @@ func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) erro
 					Identifier: translatedAtom,
 					Column:     pgsql.ColumnProperties,
 				})
-				s.treeTranslator.PushOperand(fieldIdentifierLiteral)
+				if !isEscapedPropertyLookupName(fieldIdentifierLiteral) {
+					s.treeTranslator.PushOperand(fieldIdentifierLiteral)
+				} else if unescapedLiteral, err := pgsql.AsLiteral(unescapePropertyLookupName(fieldIdentifierLiteral.Value.(string))); err != nil {
+					return err
+				} else {
+					s.treeTranslator.PushOperand(unescapedLiteral)
+				}
 
 				if err := s.treeTranslator.CompleteBinaryExpression(s.scope, pgsql.OperatorPropertyLookup); err != nil {
 					return err
@@ -300,7 +326,7 @@ func lookupRequiresElementType(typeHint pgsql.DataType, operator pgsql.Operator,
 
 func TypeCastExpression(expression pgsql.Expression, dataType pgsql.DataType) (pgsql.Expression, error) {
 	if propertyLookup, isPropertyLookup := expressionToPropertyLookupBinaryExpression(expression); isPropertyLookup {
-		var lookupTypeHint = dataType
+		lookupTypeHint := dataType
 
 		if lookupRequiresElementType(dataType, propertyLookup.Operator, propertyLookup.ROperand) {
 			// Take the base type of the array type hint: <unit> in <collection>
@@ -750,7 +776,6 @@ func rewriteIdentityOperands(scope *Scope, newExpression *pgsql.BinaryExpression
 					}
 				}
 			}
-
 		}
 	}
 

--- a/cypher/models/pgsql/translate/expression.go
+++ b/cypher/models/pgsql/translate/expression.go
@@ -41,7 +41,7 @@ func isCompositePropertyLookupTarget(expression pgsql.TypeHinted) bool {
 }
 
 func (s *Translator) translateCompositePropertyLookup(target pgsql.Expression, lookup *cypher.PropertyLookup) error {
-	if fieldIdentifierLiteral, err := propertyLookupNameLiteral(lookup.Symbol); err != nil {
+	if fieldIdentifierLiteral, err := pgsql.AsLiteral(lookup.Symbol); err != nil {
 		return err
 	} else {
 		s.treeTranslator.PushOperand(pgsql.RowColumnReference{
@@ -53,38 +53,13 @@ func (s *Translator) translateCompositePropertyLookup(target pgsql.Expression, l
 		return s.treeTranslator.CompleteBinaryExpression(s.scope, pgsql.OperatorPropertyLookup)
 	}
 }
-
-func isEscapedPropertyLookupName(literal pgsql.Literal) bool {
-	if litString, typeOK := literal.Value.(string); !typeOK {
-		return false
-	} else if len(litString) > 2 && litString[0] == '`' && litString[len(litString)-1] == '`' {
-		return true
-	}
-
-	return false
-}
-
-func unescapePropertyLookupName(name string) string {
-	return strings.ReplaceAll(name[1:len(name)-1], "``", "`")
-}
-
-func propertyLookupNameLiteral(name string) (pgsql.Literal, error) {
-	if fieldIdentifierLiteral, err := pgsql.AsLiteral(name); err != nil {
-		return pgsql.Literal{}, err
-	} else if !isEscapedPropertyLookupName(fieldIdentifierLiteral) {
-		return fieldIdentifierLiteral, nil
-	} else {
-		return pgsql.AsLiteral(unescapePropertyLookupName(fieldIdentifierLiteral.Value.(string)))
-	}
-}
-
 func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) error {
 	if translatedAtom, err := s.treeTranslator.PopOperand(); err != nil {
 		return err
 	} else {
 		switch typedTranslatedAtom := translatedAtom.(type) {
 		case pgsql.Identifier:
-			if fieldIdentifierLiteral, err := propertyLookupNameLiteral(lookup.Symbol); err != nil {
+			if fieldIdentifierLiteral, err := pgsql.AsLiteral(lookup.Symbol); err != nil {
 				return err
 			} else {
 				s.treeTranslator.PushOperand(pgsql.CompoundIdentifier{typedTranslatedAtom, pgsql.ColumnProperties})
@@ -100,7 +75,7 @@ func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) erro
 				return err
 			} else if !expressionHasCompositeProperties(expressionType) {
 				return fmt.Errorf("unsupported property lookup %s on expression type %s", lookup.Symbol, expressionType)
-			} else if fieldIdentifierLiteral, err := propertyLookupNameLiteral(lookup.Symbol); err != nil {
+			} else if fieldIdentifierLiteral, err := pgsql.AsLiteral(lookup.Symbol); err != nil {
 				return err
 			} else {
 				s.treeTranslator.PushOperand(pgsql.RowColumnReference{

--- a/cypher/models/pgsql/translate/expression.go
+++ b/cypher/models/pgsql/translate/expression.go
@@ -54,6 +54,10 @@ func (s *Translator) translateCompositePropertyLookup(target pgsql.Expression, l
 	}
 }
 func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) error {
+	if err := cypher.ValidatePropertyKeyName(lookup.Symbol); err != nil {
+		return err
+	}
+
 	if translatedAtom, err := s.treeTranslator.PopOperand(); err != nil {
 		return err
 	} else {

--- a/cypher/models/pgsql/translate/expression.go
+++ b/cypher/models/pgsql/translate/expression.go
@@ -41,7 +41,7 @@ func isCompositePropertyLookupTarget(expression pgsql.TypeHinted) bool {
 }
 
 func (s *Translator) translateCompositePropertyLookup(target pgsql.Expression, lookup *cypher.PropertyLookup) error {
-	if fieldIdentifierLiteral, err := pgsql.AsLiteral(lookup.Symbol); err != nil {
+	if fieldIdentifierLiteral, err := propertyLookupNameLiteral(lookup.Symbol); err != nil {
 		return err
 	} else {
 		s.treeTranslator.PushOperand(pgsql.RowColumnReference{
@@ -68,23 +68,27 @@ func unescapePropertyLookupName(name string) string {
 	return strings.ReplaceAll(name[1:len(name)-1], "``", "`")
 }
 
+func propertyLookupNameLiteral(name string) (pgsql.Literal, error) {
+	if fieldIdentifierLiteral, err := pgsql.AsLiteral(name); err != nil {
+		return pgsql.Literal{}, err
+	} else if !isEscapedPropertyLookupName(fieldIdentifierLiteral) {
+		return fieldIdentifierLiteral, nil
+	} else {
+		return pgsql.AsLiteral(unescapePropertyLookupName(fieldIdentifierLiteral.Value.(string)))
+	}
+}
+
 func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) error {
 	if translatedAtom, err := s.treeTranslator.PopOperand(); err != nil {
 		return err
 	} else {
 		switch typedTranslatedAtom := translatedAtom.(type) {
 		case pgsql.Identifier:
-			if fieldIdentifierLiteral, err := pgsql.AsLiteral(lookup.Symbol); err != nil {
+			if fieldIdentifierLiteral, err := propertyLookupNameLiteral(lookup.Symbol); err != nil {
 				return err
 			} else {
 				s.treeTranslator.PushOperand(pgsql.CompoundIdentifier{typedTranslatedAtom, pgsql.ColumnProperties})
-				if !isEscapedPropertyLookupName(fieldIdentifierLiteral) {
-					s.treeTranslator.PushOperand(fieldIdentifierLiteral)
-				} else if unescapedLiteral, err := pgsql.AsLiteral(unescapePropertyLookupName(fieldIdentifierLiteral.Value.(string))); err != nil {
-					return err
-				} else {
-					s.treeTranslator.PushOperand(unescapedLiteral)
-				}
+				s.treeTranslator.PushOperand(fieldIdentifierLiteral)
 
 				if err := s.treeTranslator.CompleteBinaryExpression(s.scope, pgsql.OperatorPropertyLookup); err != nil {
 					return err
@@ -96,20 +100,14 @@ func (s *Translator) translatePropertyLookup(lookup *cypher.PropertyLookup) erro
 				return err
 			} else if !expressionHasCompositeProperties(expressionType) {
 				return fmt.Errorf("unsupported property lookup %s on expression type %s", lookup.Symbol, expressionType)
-			} else if fieldIdentifierLiteral, err := pgsql.AsLiteral(lookup.Symbol); err != nil {
+			} else if fieldIdentifierLiteral, err := propertyLookupNameLiteral(lookup.Symbol); err != nil {
 				return err
 			} else {
 				s.treeTranslator.PushOperand(pgsql.RowColumnReference{
 					Identifier: translatedAtom,
 					Column:     pgsql.ColumnProperties,
 				})
-				if !isEscapedPropertyLookupName(fieldIdentifierLiteral) {
-					s.treeTranslator.PushOperand(fieldIdentifierLiteral)
-				} else if unescapedLiteral, err := pgsql.AsLiteral(unescapePropertyLookupName(fieldIdentifierLiteral.Value.(string))); err != nil {
-					return err
-				} else {
-					s.treeTranslator.PushOperand(unescapedLiteral)
-				}
+				s.treeTranslator.PushOperand(fieldIdentifierLiteral)
 
 				if err := s.treeTranslator.CompleteBinaryExpression(s.scope, pgsql.OperatorPropertyLookup); err != nil {
 					return err

--- a/cypher/models/pgsql/translate/semantic_drift_test.go
+++ b/cypher/models/pgsql/translate/semantic_drift_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/walk"
 	"github.com/specterops/dawgs/drivers/pg/pgutil"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/require"
@@ -39,4 +41,21 @@ func TestTranslatorRejectsUnsupportedPropertyLookupSourcesDirectly(t *testing.T)
 	_, err = Translate(context.Background(), query, kindMapper, nil, DefaultGraphID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported property lookup prop on expression type int8[]")
+}
+
+func TestTranslatorRejectsEmptyPropertyLookupKeys(t *testing.T) {
+	kindMapper := pgutil.NewInMemoryKindMapper()
+
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n.name`)
+	require.NoError(t, err)
+
+	err = walk.CypherStructural(query, walk.NewSimpleVisitor[cypher.SyntaxNode](func(node cypher.SyntaxNode, _ walk.VisitorHandler) {
+		if propertyLookup, typeOK := node.(*cypher.PropertyLookup); typeOK {
+			propertyLookup.Symbol = ""
+		}
+	}))
+	require.NoError(t, err)
+
+	_, err = Translate(context.Background(), query, kindMapper, nil, DefaultGraphID)
+	require.ErrorIs(t, err, cypher.ErrEmptyPropertyKeyName)
 }

--- a/integration/testdata/bed8967.json
+++ b/integration/testdata/bed8967.json
@@ -8,7 +8,7 @@
           "name": "alpha",
           "a-aaa": "alpha-hyphen",
           "has`tick": "alpha-backtick",
-          "": "alpha-empty",
+          "   ": "alpha-whitespace",
           "a\u20dd": "alpha-enclosing"
         }
       },
@@ -19,7 +19,7 @@
           "name": "beta",
           "a-aaa": "beta-hyphen",
           "has`tick": "beta-backtick",
-          "": "beta-empty",
+          "   ": "beta-whitespace",
           "a\u20dd": "beta-enclosing"
         }
       }

--- a/integration/testdata/bed8967.json
+++ b/integration/testdata/bed8967.json
@@ -1,0 +1,39 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "alpha",
+        "kinds": ["BacktickNode"],
+        "properties": {
+          "name": "alpha",
+          "a-aaa": "alpha-hyphen",
+          "has`tick": "alpha-backtick",
+          "": "alpha-empty",
+          "a\u20dd": "alpha-enclosing"
+        }
+      },
+      {
+        "id": "beta",
+        "kinds": ["BacktickNode"],
+        "properties": {
+          "name": "beta",
+          "a-aaa": "beta-hyphen",
+          "has`tick": "beta-backtick",
+          "": "beta-empty",
+          "a\u20dd": "beta-enclosing"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "start_id": "alpha",
+        "end_id": "beta",
+        "kind": "BacktickEdge",
+        "properties": {
+          "edge-key": "edge-hyphen",
+          "has`tick": "edge-backtick"
+        }
+      }
+    ]
+  }
+}

--- a/integration/testdata/cases/bed8967-backtick_property_keys.json
+++ b/integration/testdata/cases/bed8967-backtick_property_keys.json
@@ -3,13 +3,18 @@
   "cases": [
     {
       "name": "BED-8967 read escaped node property keys",
-      "cypher": "match (n:BacktickNode) return n.`a-aaa`, n.`has``tick`, n.``, n.`a\u20dd` order by n.name",
+      "cypher": "match (n:BacktickNode) return n.`a-aaa`, n.`has``tick`, n.`   `, n.`a\u20dd` order by n.name",
       "assert": {
         "ordered_row_values": [
-          ["alpha-hyphen", "alpha-backtick", "alpha-empty", "alpha-enclosing"],
-          ["beta-hyphen", "beta-backtick", "beta-empty", "beta-enclosing"]
+          ["alpha-hyphen", "alpha-backtick", "alpha-whitespace", "alpha-enclosing"],
+          ["beta-hyphen", "beta-backtick", "beta-whitespace", "beta-enclosing"]
         ]
       }
+    },
+    {
+      "name": "BED-8967 reject empty escaped property key",
+      "cypher": "match (n:BacktickNode) return n.``",
+      "assert": "query_error"
     },
     {
       "name": "BED-8967 filter node using escaped pattern property key",

--- a/integration/testdata/cases/bed8967-backtick_property_keys.json
+++ b/integration/testdata/cases/bed8967-backtick_property_keys.json
@@ -1,0 +1,47 @@
+{
+  "dataset": "bed8967",
+  "cases": [
+    {
+      "name": "BED-8967 read escaped node property keys",
+      "cypher": "match (n:BacktickNode) return n.`a-aaa`, n.`has``tick`, n.``, n.`a\u20dd` order by n.name",
+      "assert": {
+        "ordered_row_values": [
+          ["alpha-hyphen", "alpha-backtick", "alpha-empty", "alpha-enclosing"],
+          ["beta-hyphen", "beta-backtick", "beta-empty", "beta-enclosing"]
+        ]
+      }
+    },
+    {
+      "name": "BED-8967 filter node using escaped pattern property key",
+      "cypher": "match (n:BacktickNode {`a-aaa`: 'beta-hyphen'}) return n.name",
+      "assert": {"scalar_values": ["beta"]}
+    },
+    {
+      "name": "BED-8967 read escaped relationship property keys",
+      "cypher": "match (:BacktickNode {name: 'alpha'})-[r:BacktickEdge]->(:BacktickNode {name: 'beta'}) return r.`edge-key`, r.`has``tick`",
+      "assert": {"row_values": [["edge-hyphen", "edge-backtick"]]}
+    },
+    {
+      "name": "BED-8967 set escaped node property keys",
+      "cypher": "match (n:BacktickNode {name: 'mutable'}) set n.`set-key` = 'set-value', n.`has``tick` = 'updated-backtick' return n.`set-key`, n.`has``tick`",
+      "fixture": {
+        "nodes": [
+          {"id": "mutable", "kinds": ["BacktickNode"], "properties": {"name": "mutable", "has`tick": "old-backtick"}}
+        ],
+        "edges": []
+      },
+      "assert": {"row_values": [["set-value", "updated-backtick"]]}
+    },
+    {
+      "name": "BED-8967 remove escaped node property key",
+      "cypher": "match (n:BacktickNode {name: 'removable'}) remove n.`remove-key` return n.`remove-key`",
+      "fixture": {
+        "nodes": [
+          {"id": "removable", "kinds": ["BacktickNode"], "properties": {"name": "removable", "remove-key": "remove-me"}}
+        ],
+        "edges": []
+      },
+      "assert": {"scalar_values": [null]}
+    }
+  ]
+}

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -83,7 +83,7 @@ func TestBuilderRendersRawPropertyKeys(t *testing.T) {
 	builder.Apply(query.Returning(
 		query.NodeProperty("a-aaa"),
 		query.Property(query.Node(), "has`tick"),
-		query.Property(query.Node(), ""),
+		query.Property(query.Node(), "   "),
 	))
 
 	regularQuery, err := builder.Build(false)
@@ -96,7 +96,7 @@ func TestBuilderRendersRawPropertyKeys(t *testing.T) {
 		t.Fatalf("render Cypher: %v", err)
 	}
 
-	expected := "match (n) return n.`a-aaa`, n.`has``tick`, n.``"
+	expected := "match (n) return n.`a-aaa`, n.`has``tick`, n.`   `"
 	if cypher.String() != expected {
 		t.Fatalf("expected %q, got %q", expected, cypher.String())
 	}

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -78,6 +78,30 @@ func TestBuilderProjectionModifiersAreOrderIndependent(t *testing.T) {
 	}
 }
 
+func TestBuilderRendersRawPropertyKeys(t *testing.T) {
+	builder := query.NewBuilder(nil)
+	builder.Apply(query.Returning(
+		query.NodeProperty("a-aaa"),
+		query.Property(query.Node(), "has`tick"),
+		query.Property(query.Node(), ""),
+	))
+
+	regularQuery, err := builder.Build(false)
+	if err != nil {
+		t.Fatalf("build query: %v", err)
+	}
+
+	var cypher bytes.Buffer
+	if err := cypherFormat.NewCypherEmitter(false).Write(regularQuery, &cypher); err != nil {
+		t.Fatalf("render Cypher: %v", err)
+	}
+
+	expected := "match (n) return n.`a-aaa`, n.`has``tick`, n.``"
+	if cypher.String() != expected {
+		t.Fatalf("expected %q, got %q", expected, cypher.String())
+	}
+}
+
 func assertRetrieverProjection(t *testing.T, rendered string) {
 	t.Helper()
 

--- a/query/v2/query.go
+++ b/query/v2/query.go
@@ -653,6 +653,14 @@ func (s *entity[T]) ID() IdentityContinuation {
 }
 
 func (s *entity[T]) Property(propertyName string) PropertyContinuation {
+	if err := cypher.ValidatePropertyKeyName(propertyName); err != nil {
+		return &propertyContinuation{
+			comparisonContinuation: comparisonContinuation{
+				qualifierExpression: invalidExpression(err),
+			},
+		}
+	}
+
 	return &propertyContinuation{
 		comparisonContinuation: comparisonContinuation{
 			qualifierExpression: cypher.NewPropertyLookup(s.identifier.Symbol, propertyName),

--- a/query/v2/query_test.go
+++ b/query/v2/query_test.go
@@ -121,11 +121,18 @@ func TestRawPropertyKeysRenderEscaped(t *testing.T) {
 	preparedQuery, err := v2.New().Return(
 		v2.Node().Property("a-aaa"),
 		v2.Node().Property("has`tick"),
-		v2.Node().Property(""),
+		v2.Node().Property("   "),
 	).Build()
 	require.NoError(t, err)
 
-	require.Equal(t, "match (n) return n.`a-aaa`, n.`has``tick`, n.``", renderPrepared(t, preparedQuery))
+	require.Equal(t, "match (n) return n.`a-aaa`, n.`has``tick`, n.`   `", renderPrepared(t, preparedQuery))
+}
+
+func TestEmptyPropertyKeyReturnsBuildError(t *testing.T) {
+	_, err := v2.New().Return(
+		v2.Node().Property(""),
+	).Build()
+	require.ErrorIs(t, err, cypher.ErrEmptyPropertyKeyName)
 }
 
 func TestCreateSplitsDisjointNodePatterns(t *testing.T) {

--- a/query/v2/query_test.go
+++ b/query/v2/query_test.go
@@ -117,6 +117,17 @@ func TestCreateRelationshipWithExplicitEndpoints(t *testing.T) {
 	}, preparedQuery.Parameters)
 }
 
+func TestRawPropertyKeysRenderEscaped(t *testing.T) {
+	preparedQuery, err := v2.New().Return(
+		v2.Node().Property("a-aaa"),
+		v2.Node().Property("has`tick"),
+		v2.Node().Property(""),
+	).Build()
+	require.NoError(t, err)
+
+	require.Equal(t, "match (n) return n.`a-aaa`, n.`has``tick`, n.``", renderPrepared(t, preparedQuery))
+}
+
 func TestCreateSplitsDisjointNodePatterns(t *testing.T) {
 	preparedQuery, err := v2.New().Create(
 		v2.NodePattern(graph.Kinds{graph.StringKind("A")}, nil),

--- a/query/v2/util.go
+++ b/query/v2/util.go
@@ -248,6 +248,10 @@ func variableReference(value any) (*cypher.Variable, error) {
 }
 
 func propertyLookupOrError(reference any, propertyName string) cypher.Expression {
+	if err := cypher.ValidatePropertyKeyName(propertyName); err != nil {
+		return invalidExpression(err)
+	}
+
 	if variable, err := variableReference(reference); err != nil {
 		return invalidExpression(err)
 	} else {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly explain the change and its motivation. -->

Resolves: BED-8967

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [X] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of property names containing hyphens, spaces, backticks, empty values, reserved words, and Unicode characters.
  * Preserved property names correctly when reading, filtering, updating, or removing node and relationship properties.
  * Ensured generated Cypher queries consistently escape special property names.
  * Added validation and clear errors for empty property names.

* **Tests**
  * Added coverage across parsing, formatting, query building, PostgreSQL translation, and end-to-end property-key operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->