### PR TITLE
fix: escape cypher debug statement with comments across newlines BED-9065

### DIFF
--- a/cypher/models/pgsql/translate/format.go
+++ b/cypher/models/pgsql/translate/format.go
@@ -3,6 +3,7 @@ package translate
 import (
 	"bytes"
 	"context"
+	"strings"
 
 	"github.com/specterops/dawgs/cypher/models/cypher"
 	cypherFormat "github.com/specterops/dawgs/cypher/models/cypher/format"
@@ -14,17 +15,39 @@ func Translated(translation Result) (string, error) {
 	return format.Statement(translation.Statement, format.NewOutputBuilder())
 }
 
+// postgres comments can be terminated by \r, \n, or both per the source:
+// https://github.com/postgres/postgres/blob/824d5f6241ea7a0a85c9d2b3d27beb78e42a36ab/src/backend/parser/scan.l#L186-L211
+var newlineToCommentReplacer = strings.NewReplacer(
+	"\r\n", "\n-- ",
+	"\r", "\n-- ",
+	"\n", "\n-- ",
+)
+
 func FromCypher(ctx context.Context, regularQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, stripLiterals bool, graphID int32) (format.Formatted, error) {
 	var (
 		output  = &bytes.Buffer{}
 		emitter = cypherFormat.NewCypherEmitter(stripLiterals)
 	)
 
-	output.WriteString("-- ")
+	// 1. write cypher to output
 
 	if err := emitter.Write(regularQuery, output); err != nil {
 		return format.Formatted{}, err
 	}
+
+	// 2. save copy of cypher and reset output for commented cypher
+
+	raw := strings.TrimSpace(output.String())
+	output.Reset()
+
+	// 3. write commented cypher
+
+	output.WriteString("-- ") // opening comment
+	if _, err := newlineToCommentReplacer.WriteString(output, raw); err != nil {
+		return format.Formatted{}, err
+	}
+
+	// 4. continue with SQL
 
 	output.WriteString("\n")
 

--- a/cypher/models/pgsql/translate/format_test.go
+++ b/cypher/models/pgsql/translate/format_test.go
@@ -1,0 +1,38 @@
+package translate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/drivers/pg/pgutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromCypherProperlyEscapesDebugComment(t *testing.T) {
+	t.Parallel()
+
+	kindMapper := pgutil.NewInMemoryKindMapper()
+
+	query, err := frontend.ParseCypher(
+		frontend.NewContext(),
+		"MATCH (n) WHERE n.`begin\nfail1\rfail2\r\nfail3\n\rfail4` = 1 RETURN n",
+	)
+	require.NoError(t, err)
+
+	formatted, err := FromCypher(context.Background(), query, kindMapper, false, DefaultGraphID)
+	require.NoError(t, err)
+
+	IsPGNewline := func(r rune) bool {
+		return r == '\n' || r == '\r'
+	}
+	for line := range strings.FieldsFuncSeq(formatted.Statement, IsPGNewline) {
+		if strings.HasPrefix(line, "with s0") {
+			break
+		} else if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			continue
+		}
+		require.NotContains(t, line, "fail")
+	}
+}

--- a/cypher/models/pgsql/translate/format_test.go
+++ b/cypher/models/pgsql/translate/format_test.go
@@ -30,7 +30,10 @@ func TestFromCypherProperlyEscapesDebugComment(t *testing.T) {
 	for line := range strings.FieldsFuncSeq(formatted.Statement, IsPGNewline) {
 		if strings.HasPrefix(line, "with s0") {
 			break
-		} else if strings.HasPrefix(strings.TrimSpace(line), "--") {
+		}
+		is_commented := strings.HasPrefix(strings.TrimSpace(line), "--")
+		require.True(t, is_commented, "cypher line '%v' does not start with '--'", line)
+		if is_commented {
 			continue
 		}
 		require.NotContains(t, line, "fail")


### PR DESCRIPTION
## Description

Properly escapes the potentially multi line cypher statements included as a comment for debugging in the SQL output.

**See BED-9065 for additional details and testing information.**

Resolves: BED-9065

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

- Tested manually with the CLI and with a test OpenGraph payload (artifacts attached to BED-9065)
- Go Tests

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of generated SQL debug comments across multiline Cypher statements.
  * Prevented escaped identifier content from appearing in executable SQL lines.

* **Tests**
  * Added coverage to verify sensitive content remains confined to debug comments and is handled consistently across newline formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->