### PR TITLE
feat: PG VACUUM/ANALYZE on every Optimize call - BED-9161

### DIFF
--- a/drivers/pg/optimize.go
+++ b/drivers/pg/optimize.go
@@ -10,43 +10,12 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// Sum n_dead_tup and n_live_tup across every leaf partition of the parent;
-const optimizeStorageStatsQuery = `
-	SELECT
-		COALESCE(SUM(stat.n_dead_tup), 0),
-		COALESCE(SUM(stat.n_live_tup), 0)
-	FROM pg_partition_tree($1::regclass) tree
-	LEFT JOIN pg_stat_user_tables stat ON stat.relid = tree.relid
-	WHERE tree.isleaf
-`
-
 type optimizeStorageConn interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
-	QueryRow(ctx context.Context, sql string, arguments ...any) pgx.Row
 }
 
 func optimizeStorage(ctx context.Context, conn optimizeStorageConn) error {
 	targets := []string{"node", "edge"}
-	for _, table := range targets {
-		var dead, live int64
-		if err := conn.QueryRow(ctx, optimizeStorageStatsQuery, table).Scan(&dead, &live); err != nil {
-			return fmt.Errorf("query dead tuple stats for %s: %w", table, err)
-		}
-
-		total := dead + live
-		var deadTupleRatio float64
-		if total > 0 {
-			deadTupleRatio = float64(dead) / float64(total)
-		}
-
-		slog.InfoContext(ctx, "Queried PostgreSQL table storage statistics",
-			slog.String("table", table),
-			slog.Int64("dead_tuples", dead),
-			slog.Int64("live_tuples", live),
-			slog.Int64("total_tuples", total),
-			slog.Float64("dead_tuple_ratio", deadTupleRatio),
-		)
-	}
 
 	// Targeting the partitioned parents cascades to every partition.
 	stmt := "VACUUM (ANALYZE) " + strings.Join(targets, ", ")

--- a/drivers/pg/optimize.go
+++ b/drivers/pg/optimize.go
@@ -10,11 +10,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// deadTupleThreshold is the minimum fraction of dead tuples a partitioned
-// parent must accumulate across its partitions before OptimizeStorage will
-// vacuum it.
-const deadTupleThreshold = 0.1
-
 // Sum n_dead_tup and n_live_tup across every leaf partition of the parent;
 const optimizeStorageStatsQuery = `
 	SELECT
@@ -31,8 +26,8 @@ type optimizeStorageConn interface {
 }
 
 func optimizeStorage(ctx context.Context, conn optimizeStorageConn) error {
-	var targets []string
-	for _, table := range []string{"node", "edge"} {
+	targets := []string{"node", "edge"}
+	for _, table := range targets {
 		var dead, live int64
 		if err := conn.QueryRow(ctx, optimizeStorageStatsQuery, table).Scan(&dead, &live); err != nil {
 			return fmt.Errorf("query dead tuple stats for %s: %w", table, err)
@@ -50,19 +45,7 @@ func optimizeStorage(ctx context.Context, conn optimizeStorageConn) error {
 			slog.Int64("live_tuples", live),
 			slog.Int64("total_tuples", total),
 			slog.Float64("dead_tuple_ratio", deadTupleRatio),
-			slog.Float64("dead_tuple_threshold", deadTupleThreshold),
 		)
-
-		if total == 0 {
-			continue
-		}
-		if deadTupleRatio >= deadTupleThreshold {
-			targets = append(targets, table)
-		}
-	}
-
-	if len(targets) == 0 {
-		return nil
 	}
 
 	// Targeting the partitioned parents cascades to every partition.

--- a/drivers/pg/optimize_test.go
+++ b/drivers/pg/optimize_test.go
@@ -2,7 +2,6 @@ package pg
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -11,30 +10,13 @@ import (
 )
 
 func TestOptimizeStorage(t *testing.T) {
-	t.Run("always vacuums node and edge regardless of dead tuple ratios", func(t *testing.T) {
+	t.Run("always vacuums node and edge", func(t *testing.T) {
 		ctx := context.Background()
 		conn := newOptimizeStorageMockConn(t)
 
-		expectOptimizeStorageStats(conn, "node", 0, 0)
-		expectOptimizeStorageStats(conn, "edge", 9, 91)
 		expectOptimizeStorageVacuum(conn, "VACUUM (ANALYZE) node, edge")
 
 		require.NoError(t, optimizeStorage(ctx, conn))
-		require.NoError(t, conn.ExpectationsWereMet())
-	})
-
-	t.Run("returns query error", func(t *testing.T) {
-		ctx := context.Background()
-		conn := newOptimizeStorageMockConn(t)
-		expectedErr := errors.New("stats unavailable")
-
-		conn.ExpectQuery(optimizeStorageStatsQuery).
-			WithArgs("node").
-			WillReturnError(expectedErr)
-
-		err := optimizeStorage(ctx, conn)
-		require.ErrorIs(t, err, expectedErr)
-		require.ErrorContains(t, err, "query dead tuple stats for node")
 		require.NoError(t, conn.ExpectationsWereMet())
 	})
 }
@@ -46,12 +28,6 @@ func newOptimizeStorageMockConn(t *testing.T) pgxmock.PgxConnIface {
 	require.NoError(t, err)
 
 	return conn
-}
-
-func expectOptimizeStorageStats(conn pgxmock.PgxConnIface, table string, dead, live int64) {
-	conn.ExpectQuery(optimizeStorageStatsQuery).
-		WithArgs(table).
-		WillReturnRows(pgxmock.NewRows([]string{"dead", "live"}).AddRow(dead, live))
 }
 
 func expectOptimizeStorageVacuum(conn pgxmock.PgxConnIface, stmt string) {

--- a/drivers/pg/optimize_test.go
+++ b/drivers/pg/optimize_test.go
@@ -11,47 +11,12 @@ import (
 )
 
 func TestOptimizeStorage(t *testing.T) {
-	t.Run("skips vacuum when dead tuple ratios are below threshold", func(t *testing.T) {
+	t.Run("always vacuums node and edge regardless of dead tuple ratios", func(t *testing.T) {
 		ctx := context.Background()
 		conn := newOptimizeStorageMockConn(t)
 
-		expectOptimizeStorageStats(conn, "node", 9, 91)
-		expectOptimizeStorageStats(conn, "edge", 0, 0)
-
-		require.NoError(t, optimizeStorage(ctx, conn))
-		require.NoError(t, conn.ExpectationsWereMet())
-	})
-
-	t.Run("vacuums node only", func(t *testing.T) {
-		ctx := context.Background()
-		conn := newOptimizeStorageMockConn(t)
-
-		expectOptimizeStorageStats(conn, "node", 10, 90)
+		expectOptimizeStorageStats(conn, "node", 0, 0)
 		expectOptimizeStorageStats(conn, "edge", 9, 91)
-		expectOptimizeStorageVacuum(conn, "VACUUM (ANALYZE) node")
-
-		require.NoError(t, optimizeStorage(ctx, conn))
-		require.NoError(t, conn.ExpectationsWereMet())
-	})
-
-	t.Run("vacuums edge only", func(t *testing.T) {
-		ctx := context.Background()
-		conn := newOptimizeStorageMockConn(t)
-
-		expectOptimizeStorageStats(conn, "node", 9, 91)
-		expectOptimizeStorageStats(conn, "edge", 10, 90)
-		expectOptimizeStorageVacuum(conn, "VACUUM (ANALYZE) edge")
-
-		require.NoError(t, optimizeStorage(ctx, conn))
-		require.NoError(t, conn.ExpectationsWereMet())
-	})
-
-	t.Run("vacuums node and edge", func(t *testing.T) {
-		ctx := context.Background()
-		conn := newOptimizeStorageMockConn(t)
-
-		expectOptimizeStorageStats(conn, "node", 10, 90)
-		expectOptimizeStorageStats(conn, "edge", 10, 90)
 		expectOptimizeStorageVacuum(conn, "VACUUM (ANALYZE) node, edge")
 
 		require.NoError(t, optimizeStorage(ctx, conn))


### PR DESCRIPTION
## Description

Removes the thresholds from PG's Optimize function for VACUUM/ANALYZE. This will insure the DB always has updated statistics.

Resolves: BED-9161

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [X] Integration tests added / updated
- [X] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [X] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [X] Code is formatted
- [X] All existing tests pass
- [X] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database maintenance so vacuuming consistently runs for both node and edge data tables.
  * Prevented maintenance from being skipped based on dead-tuple statistics, improving storage cleanup reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->