### PR TITLE
fix: emit error constant for query OOM BED-7854

### DIFF
--- a/ops/ops.go
+++ b/ops/ops.go
@@ -13,6 +13,8 @@ import (
 	"github.com/specterops/dawgs/util/size"
 )
 
+var ErrGraphQueryExecutionFailed = errors.New("query execution failed")
+
 func FetchAllNodeProperties(tx graph.Transaction, nodes graph.NodeSet) error {
 	return tx.Nodes().Filter(
 		query.InIDs(query.NodeID(), nodes.IDs()...),
@@ -195,7 +197,7 @@ func FetchByQuery(tx graph.Transaction, query string) (QueryResult, error) {
 	)
 
 	if queryResult := tx.Query(query, map[string]any{}); queryResult.Error() != nil {
-		return result, queryResult.Error()
+		return result, fmt.Errorf("%w: %w", ErrGraphQueryExecutionFailed, queryResult.Error())
 	} else {
 		defer queryResult.Close()
 
@@ -235,7 +237,7 @@ func FetchByQuery(tx graph.Transaction, query string) (QueryResult, error) {
 				)
 
 				if currentPathSize > tx.GraphQueryMemoryLimit() || pathSetSize+literalSize > tx.GraphQueryMemoryLimit() {
-					return result, fmt.Errorf("%s - Limit: %.2f MB", "query required more memory than allowed", tx.GraphQueryMemoryLimit().Mebibytes())
+					return result, fmt.Errorf("%w - Limit: %.2f MB", ErrGraphQueryMemoryLimit, tx.GraphQueryMemoryLimit().Mebibytes())
 				}
 			}
 		}

--- a/util/errors.go
+++ b/util/errors.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
@@ -49,4 +50,16 @@ func IsNeoTimeoutError(err error) bool {
 	default:
 		return strings.Contains(e.Error(), "Neo.ClientError.Transaction.TransactionTimedOut")
 	}
+}
+
+func IsPostgresTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) &&
+		pgErr != nil &&
+		pgErr.Code == "57014" &&
+		strings.Contains(strings.ToLower(pgErr.Message), "statement timeout")
 }

--- a/util/errors_test.go
+++ b/util/errors_test.go
@@ -1,10 +1,12 @@
 package util_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/util"
@@ -36,6 +38,27 @@ func TestIsNeoTimeoutError(t *testing.T) {
 	notDriverTimeOutErr := graph.NewError(notDriverTimeOutQuery, notDriverError)
 
 	require.False(t, util.IsNeoTimeoutError(notDriverTimeOutErr))
+}
+
+func TestIsPostgresTimeoutError(t *testing.T) {
+	statementTimeoutErr := &pgconn.PgError{
+		Code:    "57014",
+		Message: "canceling statement due to statement timeout",
+	}
+
+	require.False(t, util.IsPostgresTimeoutError(nil))
+	require.True(t, util.IsPostgresTimeoutError(statementTimeoutErr))
+	require.True(t, util.IsPostgresTimeoutError(fmt.Errorf("wrapped: %w", statementTimeoutErr)))
+	require.False(t, util.IsPostgresTimeoutError(context.DeadlineExceeded))
+	require.False(t, util.IsPostgresTimeoutError(&pgconn.PgError{
+		Code:    "57014",
+		Message: "canceling statement due to user request",
+	}))
+	require.False(t, util.IsPostgresTimeoutError(&pgconn.PgError{
+		Code:    "55P03",
+		Message: "canceling statement due to lock timeout",
+	}))
+	require.False(t, util.IsPostgresTimeoutError(errors.New("statement timeout")))
 }
 
 func TestNewErrorCollector(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly explain the change and its motivation. -->

Resolves: BED-7854

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [X] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [X] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph query error reporting with a consistent execution-failure error.
  * Standardized memory-limit errors while retaining relevant limit details.
  * Improved detection of PostgreSQL statement-timeout errors, including wrapped timeout failures.
  * Distinguished statement timeouts from cancellations, deadline errors, lock timeouts, and other database errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->