### PR TITLE
fix: multipart with support for reversal rule

### DIFF
--- a/cypher/models/pgsql/optimize/direction.go
+++ b/cypher/models/pgsql/optimize/direction.go
@@ -33,6 +33,10 @@ func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
 	singleQuery := plan.Query.SingleQuery
 
 	switch {
+	case singleQuery.SinglePartQuery != nil && singleQuery.MultiPartQuery != nil:
+		// An ambiguous representation with both a single-part and a multi-part query is
+		// unsupported; rejecting it avoids silently optimizing only one of the two.
+		return false, nil
 	case singleQuery.SinglePartQuery != nil:
 		return reverseInboundTraversalSinglePartQuery(singleQuery.SinglePartQuery, map[string]struct{}{}), nil
 	case singleQuery.MultiPartQuery != nil:
@@ -46,7 +50,9 @@ func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
 // including traversals that follow a WITH projection, while carrying the symbols bound by earlier
 // segments forward so a reversal is never applied to a source endpoint provided by a prior segment.
 func reverseInboundTraversalMultiPartQuery(query *cypher.MultiPartQuery) bool {
-	if query == nil {
+	// A multi-part query without a terminal single-part query is an unsupported representation.
+	// Reject it before mutating any preceding parts so a partial reversal is never applied.
+	if query == nil || query.SinglePartQuery == nil {
 		return false
 	}
 
@@ -63,8 +69,6 @@ func reverseInboundTraversalMultiPartQuery(query *cypher.MultiPartQuery) bool {
 		if reverseInboundTraversalReadingClauses(part.ReadingClauses, declaredSymbols) {
 			applied = true
 		}
-
-		declareReadingClauseSymbols(declaredSymbols, part.ReadingClauses)
 
 		if part.With != nil {
 			declaredSymbols, _ = carryProjectionSelectivity(part.With.Projection, declaredSymbols, map[string]boundSourceSelectivity{})
@@ -88,26 +92,36 @@ func reverseInboundTraversalSinglePartQuery(query *cypher.SinglePartQuery, decla
 	return reverseInboundTraversalReadingClauses(query.ReadingClauses, declaredSymbols)
 }
 
+// reverseInboundTraversalReadingClauses evaluates each reading clause in order, declaring the
+// symbols it binds immediately after it is processed. Declaring symbols per clause rather than in a
+// single pass afterward lets a MATCH observe bindings introduced by a preceding UNWIND clause, so a
+// traversal whose source endpoint is an UNWIND binding is treated as externally bound and is not
+// reversed.
 func reverseInboundTraversalReadingClauses(readingClauses []*cypher.ReadingClause, declaredSymbols map[string]struct{}) bool {
 	var applied bool
 
 	for _, readingClause := range readingClauses {
-		if readingClause == nil || readingClause.Match == nil {
+		if readingClause == nil {
 			continue
 		}
 
-		match := readingClause.Match
-		if !match.Optional {
-			searchSymbols := whereSearchPredicateSymbols(match)
+		if match := readingClause.Match; match != nil {
+			if !match.Optional {
+				searchSymbols := whereSearchPredicateSymbols(match)
 
-			for _, patternPart := range match.Pattern {
-				if reverseInboundTraversalPatternPart(patternPart, declaredSymbols, searchSymbols) {
-					applied = true
+				for _, patternPart := range match.Pattern {
+					if reverseInboundTraversalPatternPart(patternPart, declaredSymbols, searchSymbols) {
+						applied = true
+					}
 				}
 			}
+
+			declareMatchSymbols(declaredSymbols, match)
 		}
 
-		declareMatchSymbols(declaredSymbols, match)
+		if unwind := readingClause.Unwind; unwind != nil {
+			addSymbol(declaredSymbols, variableSymbol(unwind.Variable))
+		}
 	}
 
 	return applied

--- a/cypher/models/pgsql/optimize/direction.go
+++ b/cypher/models/pgsql/optimize/direction.go
@@ -26,20 +26,72 @@ func (s InboundTraversalReversalRule) Name() string {
 }
 
 func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
-	if plan == nil || plan.Query == nil || plan.Query.SingleQuery == nil || plan.Query.SingleQuery.SinglePartQuery == nil {
+	if plan == nil || plan.Query == nil || plan.Query.SingleQuery == nil {
 		return false, nil
 	}
 
-	return reverseInboundTraversalSinglePartQuery(plan.Query.SingleQuery.SinglePartQuery), nil
+	singleQuery := plan.Query.SingleQuery
+
+	switch {
+	case singleQuery.SinglePartQuery != nil:
+		return reverseInboundTraversalSinglePartQuery(singleQuery.SinglePartQuery, map[string]struct{}{}), nil
+	case singleQuery.MultiPartQuery != nil:
+		return reverseInboundTraversalMultiPartQuery(singleQuery.MultiPartQuery), nil
+	default:
+		return false, nil
+	}
 }
 
-func reverseInboundTraversalSinglePartQuery(query *cypher.SinglePartQuery) bool {
+// reverseInboundTraversalMultiPartQuery processes each single-part segment of a multi-part query,
+// including traversals that follow a WITH projection, while carrying the symbols bound by earlier
+// segments forward so a reversal is never applied to a source endpoint provided by a prior segment.
+func reverseInboundTraversalMultiPartQuery(query *cypher.MultiPartQuery) bool {
+	if query == nil {
+		return false
+	}
+
 	var (
 		applied         bool
 		declaredSymbols = map[string]struct{}{}
 	)
 
-	for _, readingClause := range query.ReadingClauses {
+	for _, part := range query.Parts {
+		if part == nil {
+			continue
+		}
+
+		if reverseInboundTraversalReadingClauses(part.ReadingClauses, declaredSymbols) {
+			applied = true
+		}
+
+		declareReadingClauseSymbols(declaredSymbols, part.ReadingClauses)
+
+		if part.With != nil {
+			declaredSymbols, _ = carryProjectionSelectivity(part.With.Projection, declaredSymbols, map[string]boundSourceSelectivity{})
+		}
+	}
+
+	if finalPart := query.SinglePartQuery; finalPart != nil {
+		if reverseInboundTraversalSinglePartQuery(finalPart, declaredSymbols) {
+			applied = true
+		}
+	}
+
+	return applied
+}
+
+func reverseInboundTraversalSinglePartQuery(query *cypher.SinglePartQuery, declaredSymbols map[string]struct{}) bool {
+	if query == nil {
+		return false
+	}
+
+	return reverseInboundTraversalReadingClauses(query.ReadingClauses, declaredSymbols)
+}
+
+func reverseInboundTraversalReadingClauses(readingClauses []*cypher.ReadingClause, declaredSymbols map[string]struct{}) bool {
+	var applied bool
+
+	for _, readingClause := range readingClauses {
 		if readingClause == nil || readingClause.Match == nil {
 			continue
 		}

--- a/cypher/models/pgsql/optimize/optimizer_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_test.go
@@ -2127,3 +2127,118 @@ func TestInboundTraversalReversalSkipsWhenSourceCarriedAcrossWith(t *testing.T) 
 	require.False(t, patternPart.PathDirectionReversed)
 	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(patternPart))
 }
+
+func TestInboundTraversalReversalSkipsWhenSourceBoundByUnwindOfCarriedCollection(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH (n:User)
+		WHERE n.enabled = true
+		WITH collect(n) AS users
+		UNWIND users AS s
+		MATCH p = (s)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+
+	plan, err := Optimize(regularQuery)
+	require.NoError(t, err)
+
+	// The traversal source s is bound by the UNWIND of a carried collection, so reversing it would
+	// break the established drive order for the externally provided source.
+	require.Contains(t, plan.Rules, RuleResult{Name: "InboundTraversalReversal", Applied: false})
+
+	require.NotNil(t, plan.Query.SingleQuery.MultiPartQuery)
+	patternPart := plan.Query.SingleQuery.MultiPartQuery.SinglePartQuery.ReadingClauses[1].Match.Pattern[0]
+	require.False(t, patternPart.PathDirectionReversed)
+	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(patternPart))
+}
+
+func TestInboundTraversalReversalRejectsAmbiguousSingleAndMultiPartQuery(t *testing.T) {
+	t.Parallel()
+
+	singlePartQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE s.samaccountname =~ '(?i).*[ge]$' AND d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+	require.NotNil(t, singlePartQuery.SingleQuery.SinglePartQuery)
+
+	multiPartQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH (u:User)
+		WHERE u.enabled = true
+		WITH u
+		MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE s.samaccountname =~ '(?i).*[ge]$' AND d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+	require.NotNil(t, multiPartQuery.SingleQuery.MultiPartQuery)
+
+	// An ambiguous representation carrying both a single-part and a multi-part query is rejected
+	// rather than silently optimizing only one of the two.
+	plan := &Plan{
+		Query: &cypher.RegularQuery{
+			SingleQuery: &cypher.SingleQuery{
+				SinglePartQuery: singlePartQuery.SingleQuery.SinglePartQuery,
+				MultiPartQuery:  multiPartQuery.SingleQuery.MultiPartQuery,
+			},
+		},
+	}
+
+	applied, err := InboundTraversalReversalRule{}.Apply(plan)
+	require.NoError(t, err)
+	require.False(t, applied)
+
+	// Neither representation is mutated when the ambiguous query is rejected.
+	singlePartPattern := plan.Query.SingleQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0]
+	require.False(t, singlePartPattern.PathDirectionReversed)
+	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(singlePartPattern))
+
+	multiPartPattern := plan.Query.SingleQuery.MultiPartQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0]
+	require.False(t, multiPartPattern.PathDirectionReversed)
+	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(multiPartPattern))
+}
+
+func TestInboundTraversalReversalRejectsMultiPartQueryWithoutTerminalSinglePartQuery(t *testing.T) {
+	t.Parallel()
+
+	const query = `
+		MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE s.samaccountname =~ '(?i).*[ge]$' AND d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		WITH p
+		RETURN p
+	`
+
+	// Control: with the terminal single-part query intact, the qualifying pattern in the preceding
+	// part is reversed, establishing that this part is reversible.
+	control, err := frontend.ParseCypher(frontend.NewContext(), query)
+	require.NoError(t, err)
+	require.NotNil(t, control.SingleQuery.MultiPartQuery)
+	require.NotEmpty(t, control.SingleQuery.MultiPartQuery.Parts)
+	require.NotNil(t, control.SingleQuery.MultiPartQuery.SinglePartQuery)
+
+	applied, err := InboundTraversalReversalRule{}.Apply(&Plan{Query: control})
+	require.NoError(t, err)
+	require.True(t, applied)
+	require.True(t, control.SingleQuery.MultiPartQuery.Parts[0].ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
+
+	// Removing the terminal single-part query models an unsupported multi-part representation, which
+	// is rejected up front so the preceding part is left untouched.
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), query)
+	require.NoError(t, err)
+	multiPartQuery := regularQuery.SingleQuery.MultiPartQuery
+	require.NotNil(t, multiPartQuery)
+	require.NotEmpty(t, multiPartQuery.Parts)
+	multiPartQuery.SinglePartQuery = nil
+
+	applied, err = InboundTraversalReversalRule{}.Apply(&Plan{Query: regularQuery})
+	require.NoError(t, err)
+	require.False(t, applied)
+
+	patternPart := multiPartQuery.Parts[0].ReadingClauses[0].Match.Pattern[0]
+	require.False(t, patternPart.PathDirectionReversed)
+	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(patternPart))
+}

--- a/cypher/models/pgsql/optimize/optimizer_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_test.go
@@ -2078,3 +2078,52 @@ func TestInboundTraversalReversalSkipsShortestPathPattern(t *testing.T) {
 	require.False(t, patternPart.PathDirectionReversed)
 	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(patternPart))
 }
+
+func TestInboundTraversalReversalReversesQualifyingTraversalAfterWith(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH (u:User)
+		WHERE u.enabled = true
+		WITH u
+		MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE s.samaccountname =~ '(?i).*[ge]$' AND d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+
+	plan, err := Optimize(regularQuery)
+	require.NoError(t, err)
+	require.Contains(t, plan.Rules, RuleResult{Name: "InboundTraversalReversal", Applied: true})
+
+	require.NotNil(t, plan.Query.SingleQuery.MultiPartQuery)
+	patternPart := plan.Query.SingleQuery.MultiPartQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0]
+	require.True(t, patternPart.PathDirectionReversed)
+
+	// The traversal following the WITH is driven from the constrained d:Computer terminal inward
+	// toward s:User, with each relationship direction flipped from outbound to inbound.
+	require.Equal(t, []string{"d", "g", "s"}, patternNodeSymbols(patternPart))
+	require.Equal(t, []graph.Direction{graph.DirectionInbound, graph.DirectionInbound}, patternRelationshipDirections(patternPart))
+}
+
+func TestInboundTraversalReversalSkipsWhenSourceCarriedAcrossWith(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH (s:User)
+		WITH s
+		MATCH p = (s)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+
+	plan, err := Optimize(regularQuery)
+	require.NoError(t, err)
+	require.Contains(t, plan.Rules, RuleResult{Name: "InboundTraversalReversal", Applied: false})
+
+	require.NotNil(t, plan.Query.SingleQuery.MultiPartQuery)
+	patternPart := plan.Query.SingleQuery.MultiPartQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0]
+	require.False(t, patternPart.PathDirectionReversed)
+	require.Equal(t, []string{"s", "g", "d"}, patternNodeSymbols(patternPart))
+}

--- a/integration/testdata/cases/optimizer_inline.json
+++ b/integration/testdata/cases/optimizer_inline.json
@@ -356,6 +356,78 @@
         "path_node_ids": [["role", "direct-user"], ["role", "delegated-group"], ["role", "delegated-group", "delegated-user"]],
         "path_edge_kinds": [["AZHasRole"], ["AZHasRole"], ["AZHasRole", "AZMemberOf"]]
       }
+    },
+    {
+      "name": "inbound traversal reversal returns valid path for traversal after WITH",
+      "cypher": "MATCH (u:User) WHERE u.enabled = true WITH u MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer) WHERE d.operatingsystem CONTAINS 'WINDOWS SERVER' RETURN p",
+      "fixture": {
+        "nodes": [
+          {"id": "anchor", "kinds": ["User"], "properties": {"enabled": true}},
+          {"id": "s1", "kinds": ["User"]},
+          {"id": "g1", "kinds": ["Group"]},
+          {"id": "g2", "kinds": ["Group"]},
+          {"id": "d1", "kinds": ["Computer"], "properties": {"operatingsystem": "WINDOWS SERVER 2019"}},
+          {"id": "d2", "kinds": ["Computer"], "properties": {"operatingsystem": "WINDOWS 10"}}
+        ],
+        "edges": [
+          {"start_id": "s1", "end_id": "g1", "kind": "MemberOf"},
+          {"start_id": "g1", "end_id": "d1", "kind": "AdminTo"},
+          {"start_id": "s1", "end_id": "g2", "kind": "MemberOf"},
+          {"start_id": "g2", "end_id": "d2", "kind": "AdminTo"}
+        ]
+      },
+      "assert": {
+        "row_count": 1,
+        "path_node_ids": [["s1", "g1", "d1"]],
+        "path_edge_kinds": [["MemberOf", "AdminTo"]]
+      }
+    },
+    {
+      "name": "inbound traversal reversal returns valid path for traversal before WITH barrier",
+      "cypher": "MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer) WHERE d.operatingsystem CONTAINS 'WINDOWS SERVER' WITH p RETURN p",
+      "fixture": {
+        "nodes": [
+          {"id": "s1", "kinds": ["User"]},
+          {"id": "s2", "kinds": ["User"]},
+          {"id": "g1", "kinds": ["Group"]},
+          {"id": "g2", "kinds": ["Group"]},
+          {"id": "d1", "kinds": ["Computer"], "properties": {"operatingsystem": "WINDOWS SERVER 2022"}},
+          {"id": "d2", "kinds": ["Computer"], "properties": {"operatingsystem": "LINUX"}}
+        ],
+        "edges": [
+          {"start_id": "s1", "end_id": "g1", "kind": "MemberOf"},
+          {"start_id": "g1", "end_id": "d1", "kind": "AdminTo"},
+          {"start_id": "s2", "end_id": "g2", "kind": "MemberOf"},
+          {"start_id": "g2", "end_id": "d2", "kind": "AdminTo"}
+        ]
+      },
+      "assert": {
+        "row_count": 1,
+        "path_node_ids": [["s1", "g1", "d1"]],
+        "path_edge_kinds": [["MemberOf", "AdminTo"]]
+      }
+    },
+    {
+      "name": "inbound traversal reversal skipped for source carried across WITH still returns valid path",
+      "cypher": "MATCH (s:User) WHERE s.samaccountname =~ '(?i)admin.*' WITH s MATCH p = (s)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer) WHERE d.operatingsystem CONTAINS 'WINDOWS SERVER' RETURN p",
+      "fixture": {
+        "nodes": [
+          {"id": "admin", "kinds": ["User"], "properties": {"samaccountname": "admin-01"}},
+          {"id": "bob", "kinds": ["User"], "properties": {"samaccountname": "bob-01"}},
+          {"id": "g1", "kinds": ["Group"]},
+          {"id": "d1", "kinds": ["Computer"], "properties": {"operatingsystem": "WINDOWS SERVER 2019"}}
+        ],
+        "edges": [
+          {"start_id": "admin", "end_id": "g1", "kind": "MemberOf"},
+          {"start_id": "bob", "end_id": "g1", "kind": "MemberOf"},
+          {"start_id": "g1", "end_id": "d1", "kind": "AdminTo"}
+        ]
+      },
+      "assert": {
+        "row_count": 1,
+        "path_node_ids": [["admin", "g1", "d1"]],
+        "path_edge_kinds": [["MemberOf", "AdminTo"]]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly explain the change and its motivation. -->

Resolves: <TICKET_OR_ISSUE_NUMBER>

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [ ] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [ ] Code is formatted
- [ ] All existing tests pass
- [ ] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query optimization across `WITH` clauses.
  * Correctly reverses eligible inbound traversals when source bindings are not carried forward.
  * Preserves traversal direction when source bindings remain available.
  * Added coverage for multi-part queries and filtered sources to ensure valid path reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->