### PR TITLE
feat: cypher to sql translation cache - BED-9469

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Run the package benchmark suite with:
 make test_bench
 ```
 
+The PostgreSQL driver has a bounded, driver-wide Cypher compilation cache for both text Cypher and programmatic graph
+queries. Its default capacity is 256 entries; callers that need a different capacity can use
+`pg.NewDriverWithOptions`. The process-wide `pg.SetOptimizedTranslation` switch selects baseline translation for
+newly started compilations across every PostgreSQL driver in the process. See
+[PostgreSQL translation](docs/postgresql_translation.md#translation-cache) for the cache contract and rollback controls.
+
 Use `cmd/benchdiff` to compare benchmarks between two committed refs without changing the active worktree:
 
 ```bash

--- a/cypher/models/cypher/format/format.go
+++ b/cypher/models/cypher/format/format.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/walk"
 
 	"github.com/specterops/dawgs/graph"
 )
@@ -1217,9 +1218,51 @@ func (s Emitter) Write(regularQuery *cypher.RegularQuery, writer io.Writer) erro
 }
 
 func RegularQuery(query *cypher.RegularQuery, stripLiterals bool) (string, error) {
+	return regularQuery(query, NewCypherEmitter(stripLiterals))
+}
+
+// RegularQueryWithParameterSequence formats a regular query with deterministic
+// parameter names by structural occurrence while leaving the source tree
+// unchanged.
+func RegularQueryWithParameterSequence(query *cypher.RegularQuery, stripLiterals bool, parameterSequence []string) (string, error) {
+	owned := cypher.Copy(query)
+	rewriter := parameterSequenceRewriter{
+		Visitor: walk.NewVisitor[cypher.SyntaxNode](),
+		symbols: parameterSequence,
+	}
+	if err := walk.Cypher(owned, &rewriter); err != nil {
+		return "", err
+	} else if rewriter.index != len(rewriter.symbols) {
+		return "", fmt.Errorf("parameter sequence has more symbols than query parameters")
+	}
+
+	return RegularQuery(owned, stripLiterals)
+}
+
+type parameterSequenceRewriter struct {
+	walk.Visitor[cypher.SyntaxNode]
+	symbols []string
+	index   int
+}
+
+func (s *parameterSequenceRewriter) Enter(node cypher.SyntaxNode) {
+	parameter, isParameter := node.(*cypher.Parameter)
+	if !isParameter {
+		return
+	}
+	if s.index == len(s.symbols) {
+		s.SetErrorf("parameter sequence has fewer symbols than query parameters")
+		return
+	}
+
+	parameter.Symbol = s.symbols[s.index]
+	s.index++
+}
+
+func regularQuery(query *cypher.RegularQuery, emitter Emitter) (string, error) {
 	buffer := &bytes.Buffer{}
 
-	if err := NewCypherEmitter(stripLiterals).Write(query, buffer); err != nil {
+	if err := emitter.Write(query, buffer); err != nil {
 		return "", err
 	} else {
 		return buffer.String(), nil

--- a/cypher/models/cypher/format/format_test.go
+++ b/cypher/models/cypher/format/format_test.go
@@ -44,6 +44,30 @@ func TestCypherEmitter_FormatsMapLiteralInKeyOrder(t *testing.T) {
 	require.Equal(t, "{a: 1, b: 2}", buffer.String())
 }
 
+func TestRegularQueryWithParameterSequenceFormatsWithoutMutatingInput(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "match (n) where n.first = $value and n.second = $value return n")
+	require.NoError(t, err)
+
+	formatted, err := format.RegularQueryWithParameterSequence(regularQuery, false, []string{"first", "second"})
+	require.NoError(t, err)
+	require.Equal(t, "match (n) where n.first = $first and n.second = $second return n", formatted)
+
+	original, err := format.RegularQuery(regularQuery, false)
+	require.NoError(t, err)
+	require.Equal(t, "match (n) where n.first = $value and n.second = $value return n", original)
+}
+
+func TestRegularQueryWithParameterSequenceRejectsMismatchedSymbols(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "return $value")
+	require.NoError(t, err)
+
+	_, err = format.RegularQueryWithParameterSequence(regularQuery, false, nil)
+	require.ErrorContains(t, err, "fewer symbols")
+
+	_, err = format.RegularQueryWithParameterSequence(regularQuery, false, []string{"first", "second"})
+	require.ErrorContains(t, err, "more symbols")
+}
+
 func TestCypherEmitter_FormatsMapLiteralPropertyKeys(t *testing.T) {
 	var (
 		buffer  = &bytes.Buffer{}

--- a/cypher/models/pgsql/optimize/direction.go
+++ b/cypher/models/pgsql/optimize/direction.go
@@ -25,10 +25,19 @@ func (s InboundTraversalReversalRule) Name() string {
 	return "InboundTraversalReversal"
 }
 
+func (s InboundTraversalReversalRule) usesLazyCopy() bool {
+	return true
+}
+
 func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
 	if plan == nil || plan.Query == nil || plan.Query.SingleQuery == nil {
 		return false, nil
 	}
+	if !queryWouldReverseInboundTraversal(plan.Query) {
+		return false, nil
+	}
+
+	plan.EnsureMutable()
 
 	singleQuery := plan.Query.SingleQuery
 
@@ -44,6 +53,72 @@ func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+func queryWouldReverseInboundTraversal(query *cypher.RegularQuery) bool {
+	if query == nil || query.SingleQuery == nil {
+		return false
+	}
+
+	singleQuery := query.SingleQuery
+	switch {
+	case singleQuery.SinglePartQuery != nil && singleQuery.MultiPartQuery != nil:
+		return false
+	case singleQuery.SinglePartQuery != nil:
+		return readingClausesWouldReverseInboundTraversal(singleQuery.SinglePartQuery.ReadingClauses, map[string]struct{}{})
+	case singleQuery.MultiPartQuery != nil:
+		return multiPartQueryWouldReverseInboundTraversal(singleQuery.MultiPartQuery)
+	default:
+		return false
+	}
+}
+
+func multiPartQueryWouldReverseInboundTraversal(query *cypher.MultiPartQuery) bool {
+	if query == nil || query.SinglePartQuery == nil {
+		return false
+	}
+
+	declaredSymbols := map[string]struct{}{}
+	for _, part := range query.Parts {
+		if part == nil {
+			continue
+		}
+
+		if readingClausesWouldReverseInboundTraversal(part.ReadingClauses, declaredSymbols) {
+			return true
+		}
+		if part.With != nil {
+			declaredSymbols, _ = carryProjectionSelectivity(part.With.Projection, declaredSymbols, map[string]boundSourceSelectivity{})
+		}
+	}
+
+	return readingClausesWouldReverseInboundTraversal(query.SinglePartQuery.ReadingClauses, declaredSymbols)
+}
+
+func readingClausesWouldReverseInboundTraversal(readingClauses []*cypher.ReadingClause, declaredSymbols map[string]struct{}) bool {
+	for _, readingClause := range readingClauses {
+		if readingClause == nil {
+			continue
+		}
+
+		if match := readingClause.Match; match != nil {
+			if !match.Optional {
+				searchSymbols := whereSearchPredicateSymbols(match)
+				for _, patternPart := range match.Pattern {
+					if inboundTraversalReversalCandidate(patternPart, declaredSymbols, searchSymbols) {
+						return true
+					}
+				}
+			}
+			declareMatchSymbols(declaredSymbols, match)
+		}
+
+		if unwind := readingClause.Unwind; unwind != nil {
+			addSymbol(declaredSymbols, variableSymbol(unwind.Variable))
+		}
+	}
+
+	return false
 }
 
 // reverseInboundTraversalMultiPartQuery processes each single-part segment of a multi-part query,

--- a/cypher/models/pgsql/optimize/lowering_plan.go
+++ b/cypher/models/pgsql/optimize/lowering_plan.go
@@ -109,14 +109,15 @@ func appendQueryPartLowerings(
 	if err != nil {
 		return err
 	}
+	indexedPatternPredicates := indexedPatternPredicatesInQueryPart(queryPart)
 
 	appendExactRangeExpansionDecisions(plan, queryPartIndex, readingClauses)
-	appendPatternPredicateExactRangeExpansionDecisions(plan, queryPartIndex, queryPart)
+	appendPatternPredicateExactRangeExpansionDecisions(plan, queryPartIndex, indexedPatternPredicates)
 	appendPathRelationshipPredicateDecisions(plan, queryPartIndex, queryPart)
 	appendProjectionPruningDecisions(plan, queryPartIndex, readingClauses, sourceReferences)
 	appendLatePathMaterializationDecisions(plan, queryPartIndex, readingClauses, sourceReferences)
-	appendPatternPredicateProjectionLowerings(plan, queryPartIndex, queryPart, sourceReferences)
-	appendPatternPredicatePlacementDecisions(plan, queryPartIndex, queryPart)
+	appendPatternPredicateProjectionLowerings(plan, queryPartIndex, indexedPatternPredicates, sourceReferences)
+	appendPatternPredicatePlacementDecisions(plan, queryPartIndex, indexedPatternPredicates)
 	appendExpandIntoDecisions(plan, queryPartIndex, readingClauses)
 	appendTraversalDirectionDecisions(plan, queryPartIndex, readingClauses, bindingPredicateSymbols(predicateAttachments, queryPartIndex), initialDeclaredSymbols, initialSelectivity)
 	shortestPathSearchSymbols := shortestPathSearchPredicateSymbols(readingClauses)
@@ -143,8 +144,8 @@ func appendExactRangeExpansionDecisions(plan *LoweringPlan, queryPartIndex int, 
 	}
 }
 
-func appendPatternPredicateExactRangeExpansionDecisions(plan *LoweringPlan, queryPartIndex int, queryPart cypher.SyntaxNode) {
-	for _, indexedPredicate := range indexedPatternPredicatesInQueryPart(queryPart) {
+func appendPatternPredicateExactRangeExpansionDecisions(plan *LoweringPlan, queryPartIndex int, indexedPredicates []indexedPatternPredicate) {
+	for _, indexedPredicate := range indexedPredicates {
 		patternPart := patternPartForPredicate(indexedPredicate.Predicate)
 		appendPatternExactRangeExpansionDecisions(plan, PatternTarget{
 			QueryPartIndex: queryPartIndex,
@@ -397,8 +398,8 @@ func appendPatternProjectionPruningDecisions(plan *LoweringPlan, target PatternT
 	}
 }
 
-func appendPatternPredicateProjectionLowerings(plan *LoweringPlan, queryPartIndex int, queryPart cypher.SyntaxNode, sourceReferences map[string]struct{}) {
-	for _, indexedPredicate := range indexedPatternPredicatesInQueryPart(queryPart) {
+func appendPatternPredicateProjectionLowerings(plan *LoweringPlan, queryPartIndex int, indexedPredicates []indexedPatternPredicate, sourceReferences map[string]struct{}) {
+	for _, indexedPredicate := range indexedPredicates {
 		var (
 			predicate   = indexedPredicate.Predicate
 			patternPart = patternPartForPredicate(predicate)
@@ -422,8 +423,8 @@ func appendPatternPredicateProjectionLowerings(plan *LoweringPlan, queryPartInde
 	}
 }
 
-func appendPatternPredicatePlacementDecisions(plan *LoweringPlan, queryPartIndex int, queryPart cypher.SyntaxNode) {
-	for _, indexedPredicate := range indexedPatternPredicatesInQueryPart(queryPart) {
+func appendPatternPredicatePlacementDecisions(plan *LoweringPlan, queryPartIndex int, indexedPredicates []indexedPatternPredicate) {
+	for _, indexedPredicate := range indexedPredicates {
 		var (
 			predicate   = indexedPredicate.Predicate
 			patternPart = patternPartForPredicate(predicate)
@@ -1060,6 +1061,11 @@ func propertyLookupVariableSymbol(expression cypher.Expression) (string, bool) {
 }
 
 func expressionReferencesAnySource(expression cypher.Expression) bool {
+	switch expression.(type) {
+	case nil, *cypher.Literal, *cypher.Parameter:
+		return false
+	}
+
 	references, err := collectReferencedSourceIdentifiers(expression)
 	return err != nil || len(references) > 0
 }

--- a/cypher/models/pgsql/optimize/optimizer.go
+++ b/cypher/models/pgsql/optimize/optimizer.go
@@ -11,6 +11,14 @@ type analysisPreservingRule interface {
 	preservesAnalysis() bool
 }
 
+// lazyCopyRule promises that Apply does not mutate the input query unless it
+// first calls Plan.EnsureMutable. Built-in rules use this to avoid copying a
+// query when no rewrite applies. Third-party rules retain the historical safe
+// behavior: the optimizer copies before invoking them.
+type lazyCopyRule interface {
+	usesLazyCopy() bool
+}
+
 type RuleResult struct {
 	Name    string `json:"name"`
 	Applied bool   `json:"applied"`
@@ -39,6 +47,18 @@ type Plan struct {
 	LoweringPlan         LoweringPlan
 	Rules                []RuleResult
 	PredicateAttachments []PredicateAttachment
+	queryCopied          bool
+}
+
+// EnsureMutable gives a rule an owned query before it changes the AST. It is
+// intentionally idempotent so multiple applied rules share one copy.
+func (s *Plan) EnsureMutable() *cypher.RegularQuery {
+	if s != nil && !s.queryCopied && s.Query != nil {
+		s.Query = cypher.Copy(s.Query)
+		s.queryCopied = true
+	}
+
+	return s.Query
 }
 
 type Optimizer struct {
@@ -63,17 +83,46 @@ func Optimize(query *cypher.RegularQuery) (Plan, error) {
 	return NewOptimizer(DefaultRules()...).Optimize(query)
 }
 
+// OptimizeBorrowed optimizes query without copying it up front. The returned
+// plan aliases query when no rewrite applies; rules must call EnsureMutable
+// before modifying the tree. It is intended for callers that already own the
+// input tree and can treat the returned plan as read-only.
+func OptimizeBorrowed(query *cypher.RegularQuery) (Plan, error) {
+	return NewOptimizer(DefaultRules()...).OptimizeBorrowed(query)
+}
+
+// Optimize preserves the historical ownership contract: the returned plan
+// always owns its query independently of the caller's input.
 func (s Optimizer) Optimize(query *cypher.RegularQuery) (Plan, error) {
 	if query == nil {
 		return Plan{}, nil
 	}
 
+	return s.optimize(cypher.Copy(query), true)
+}
+
+// OptimizeBorrowed applies the optimizer without copying query until a rule
+// needs to mutate it. See OptimizeBorrowed for ownership details.
+func (s Optimizer) OptimizeBorrowed(query *cypher.RegularQuery) (Plan, error) {
+	return s.optimize(query, false)
+}
+
+func (s Optimizer) optimize(query *cypher.RegularQuery, queryCopied bool) (Plan, error) {
+	if query == nil {
+		return Plan{}, nil
+	}
+
 	plan := Plan{
-		Query: cypher.Copy(query),
+		Query:       query,
+		queryCopied: queryCopied,
 	}
 	plan.Analysis = Analyze(plan.Query)
 
 	for _, rule := range s.rules {
+		if lazyRule, usesLazyCopy := rule.(lazyCopyRule); !usesLazyCopy || !lazyRule.usesLazyCopy() {
+			plan.EnsureMutable()
+		}
+
 		applied, err := rule.Apply(&plan)
 		if err != nil {
 			return Plan{}, err
@@ -110,6 +159,10 @@ func (s PredicateAttachmentRule) Name() string {
 }
 
 func (s PredicateAttachmentRule) preservesAnalysis() bool {
+	return true
+}
+
+func (s PredicateAttachmentRule) usesLazyCopy() bool {
 	return true
 }
 

--- a/cypher/models/pgsql/optimize/optimizer.go
+++ b/cypher/models/pgsql/optimize/optimizer.go
@@ -7,6 +7,10 @@ type Rule interface {
 	Apply(*Plan) (bool, error)
 }
 
+type analysisPreservingRule interface {
+	preservesAnalysis() bool
+}
+
 type RuleResult struct {
 	Name    string `json:"name"`
 	Applied bool   `json:"applied"`
@@ -79,7 +83,10 @@ func (s Optimizer) Optimize(query *cypher.RegularQuery) (Plan, error) {
 			Name:    rule.Name(),
 			Applied: applied,
 		})
-		plan.Analysis = Analyze(plan.Query)
+
+		if applied && !rulePreservesAnalysis(rule) {
+			plan.Analysis = Analyze(plan.Query)
+		}
 	}
 
 	if loweringPlan, err := BuildLoweringPlan(plan.Query, plan.PredicateAttachments); err != nil {
@@ -91,10 +98,19 @@ func (s Optimizer) Optimize(query *cypher.RegularQuery) (Plan, error) {
 	return plan, nil
 }
 
+func rulePreservesAnalysis(rule Rule) bool {
+	preservingRule, preserves := rule.(analysisPreservingRule)
+	return preserves && preservingRule.preservesAnalysis()
+}
+
 type PredicateAttachmentRule struct{}
 
 func (s PredicateAttachmentRule) Name() string {
 	return "PredicateAttachment"
+}
+
+func (s PredicateAttachmentRule) preservesAnalysis() bool {
+	return true
 }
 
 func (s PredicateAttachmentRule) Apply(plan *Plan) (bool, error) {

--- a/cypher/models/pgsql/optimize/optimizer_benchmark_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_benchmark_test.go
@@ -1,0 +1,34 @@
+package optimize
+
+import (
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/frontend"
+)
+
+const trivialOptimizerBenchmarkQuery = `MATCH (n) RETURN n`
+
+func BenchmarkOptimizeTrivialQuery(b *testing.B) {
+	benchmarkOptimizeQuery(b, trivialOptimizerBenchmarkQuery)
+}
+
+func BenchmarkOptimizeADCSQuery(b *testing.B) {
+	benchmarkOptimizeQuery(b, adcsQuery)
+}
+
+func benchmarkOptimizeQuery(b *testing.B, query string) {
+	b.Helper()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), query)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for idx := 0; idx < b.N; idx++ {
+		if _, err := Optimize(regularQuery); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cypher/models/pgsql/optimize/optimizer_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_test.go
@@ -23,6 +23,17 @@ func (s testRule) Apply(plan *Plan) (bool, error) {
 	return false, nil
 }
 
+type analysisMutatingTestRule struct{}
+
+func (s analysisMutatingTestRule) Name() string {
+	return "analysis_mutating"
+}
+
+func (s analysisMutatingTestRule) Apply(plan *Plan) (bool, error) {
+	plan.Query.SingleQuery.SinglePartQuery.ReadingClauses = nil
+	return true, nil
+}
+
 type testBindingLookup map[pgsql.Identifier]pgsql.DataType
 
 func (s testBindingLookup) LookupDataType(identifier pgsql.Identifier) (pgsql.DataType, bool) {
@@ -148,6 +159,79 @@ func TestOptimizerRunsRulesAndRefreshesAnalysis(t *testing.T) {
 	require.Equal(t, []RuleResult{{Name: "test", Applied: false}}, plan.Rules)
 	require.Len(t, plan.Analysis.QueryParts, 1)
 	require.Len(t, plan.Analysis.QueryParts[0].Regions, 1)
+}
+
+func TestOptimizerRefreshesAnalysisAfterAppliedMutatingRule(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
+	require.NoError(t, err)
+
+	plan, err := NewOptimizer(analysisMutatingTestRule{}).Optimize(regularQuery)
+	require.NoError(t, err)
+	require.Equal(t, []RuleResult{{
+		Name:    "analysis_mutating",
+		Applied: true,
+	}}, plan.Rules)
+	require.Len(t, plan.Analysis.QueryParts, 1)
+	require.Empty(t, plan.Analysis.QueryParts[0].Regions)
+}
+
+func TestRulePreservesAnalysis(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, rulePreservesAnalysis(PredicateAttachmentRule{}))
+	require.False(t, rulePreservesAnalysis(testRule{name: "test"}))
+}
+
+func TestExpressionReferencesAnySource(t *testing.T) {
+	t.Parallel()
+
+	variableList := cypher.NewListLiteral()
+	*variableList = append(*variableList, cypher.NewVariableWithSymbol("n"))
+
+	literalList := cypher.NewListLiteral()
+	*literalList = append(*literalList, cypher.NewLiteral(1, false))
+
+	testCases := []struct {
+		name       string
+		expression cypher.Expression
+		expected   bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:       "literal",
+			expression: cypher.NewLiteral(1, false),
+		},
+		{
+			name:       "parameter",
+			expression: cypher.NewParameter("id", nil),
+		},
+		{
+			name:       "variable",
+			expression: cypher.NewVariableWithSymbol("n"),
+			expected:   true,
+		},
+		{
+			name:       "literal list",
+			expression: literalList,
+		},
+		{
+			name:       "variable list",
+			expression: variableList,
+			expected:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, testCase.expected, expressionReferencesAnySource(testCase.expression))
+		})
+	}
 }
 
 func TestDefaultPredicateAttachmentRuleReportsSkippedWhenNoPredicatesExist(t *testing.T) {

--- a/cypher/models/pgsql/optimize/optimizer_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_test.go
@@ -41,7 +41,7 @@ func (s testBindingLookup) LookupDataType(identifier pgsql.Identifier) (pgsql.Da
 	return dataType, found
 }
 
-func TestOptimizeCopiesAndAnalyzesQuery(t *testing.T) {
+func TestOptimizePreservesUnchangedQueryAndAnalyzesIt(t *testing.T) {
 	t.Parallel()
 
 	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), adcsQuery)
@@ -59,6 +59,34 @@ func TestOptimizeCopiesAndAnalyzesQuery(t *testing.T) {
 		{Name: "PredicateAttachment", Applied: true},
 	}, plan.Rules)
 	require.Len(t, plan.PredicateAttachments, 2)
+}
+
+func TestOptimizeBorrowedPreservesUnchangedQuery(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), adcsQuery)
+	require.NoError(t, err)
+
+	plan, err := OptimizeBorrowed(regularQuery)
+	require.NoError(t, err)
+	require.Same(t, regularQuery, plan.Query)
+}
+
+func TestOptimizeCopiesOnlyWhenDefaultRuleMutates(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE s.samaccountname =~ '(?i).*[ge]$' AND d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+
+	plan, err := OptimizeBorrowed(regularQuery)
+	require.NoError(t, err)
+	require.NotSame(t, regularQuery, plan.Query)
+	require.False(t, regularQuery.SingleQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
+	require.True(t, plan.Query.SingleQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
 }
 
 func TestOptimizePlansADCSFanoutRewrite(t *testing.T) {
@@ -154,7 +182,9 @@ func TestOptimizerRunsRulesAndRefreshesAnalysis(t *testing.T) {
 	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
 	require.NoError(t, err)
 
-	plan, err := NewOptimizer(testRule{name: "test"}).Optimize(regularQuery)
+	plan, err := NewOptimizer(testRule{
+		name: "test",
+	}).Optimize(regularQuery)
 	require.NoError(t, err)
 	require.Equal(t, []RuleResult{{Name: "test", Applied: false}}, plan.Rules)
 	require.Len(t, plan.Analysis.QueryParts, 1)
@@ -181,7 +211,9 @@ func TestRulePreservesAnalysis(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, rulePreservesAnalysis(PredicateAttachmentRule{}))
-	require.False(t, rulePreservesAnalysis(testRule{name: "test"}))
+	require.False(t, rulePreservesAnalysis(testRule{
+		name: "test",
+	}))
 }
 
 func TestExpressionReferencesAnySource(t *testing.T) {
@@ -2304,10 +2336,13 @@ func TestInboundTraversalReversalRejectsMultiPartQueryWithoutTerminalSinglePartQ
 	require.NotEmpty(t, control.SingleQuery.MultiPartQuery.Parts)
 	require.NotNil(t, control.SingleQuery.MultiPartQuery.SinglePartQuery)
 
-	applied, err := InboundTraversalReversalRule{}.Apply(&Plan{Query: control})
+	plan := Plan{
+		Query: control,
+	}
+	applied, err := InboundTraversalReversalRule{}.Apply(&plan)
 	require.NoError(t, err)
 	require.True(t, applied)
-	require.True(t, control.SingleQuery.MultiPartQuery.Parts[0].ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
+	require.True(t, plan.Query.SingleQuery.MultiPartQuery.Parts[0].ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
 
 	// Removing the terminal single-part query models an unsupported multi-part representation, which
 	// is rejected up front so the preceding part is left untouched.
@@ -2318,7 +2353,9 @@ func TestInboundTraversalReversalRejectsMultiPartQueryWithoutTerminalSinglePartQ
 	require.NotEmpty(t, multiPartQuery.Parts)
 	multiPartQuery.SinglePartQuery = nil
 
-	applied, err = InboundTraversalReversalRule{}.Apply(&Plan{Query: regularQuery})
+	applied, err = InboundTraversalReversalRule{}.Apply(&Plan{
+		Query: regularQuery,
+	})
 	require.NoError(t, err)
 	require.False(t, applied)
 

--- a/cypher/models/pgsql/optimize/reordering.go
+++ b/cypher/models/pgsql/optimize/reordering.go
@@ -13,10 +13,19 @@ func (s ConservativePatternReorderingRule) Name() string {
 	return "ConservativePatternReordering"
 }
 
+func (s ConservativePatternReorderingRule) usesLazyCopy() bool {
+	return true
+}
+
 func (s ConservativePatternReorderingRule) Apply(plan *Plan) (bool, error) {
 	if plan == nil || plan.Query == nil || plan.Query.SingleQuery == nil {
 		return false, nil
 	}
+	if !queryWouldReorder(plan.Query, plan.Analysis) {
+		return false, nil
+	}
+
+	plan.EnsureMutable()
 
 	if plan.Query.SingleQuery.MultiPartQuery != nil {
 		return reorderMultiPartQuery(plan.Query.SingleQuery.MultiPartQuery, plan.Analysis), nil
@@ -27,6 +36,39 @@ func (s ConservativePatternReorderingRule) Apply(plan *Plan) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func queryWouldReorder(query *cypher.RegularQuery, analysis Analysis) bool {
+	if query == nil || query.SingleQuery == nil {
+		return false
+	}
+
+	if multiPart := query.SingleQuery.MultiPartQuery; multiPart != nil {
+		for partIndex, part := range multiPart.Parts {
+			if part == nil {
+				continue
+			}
+			if queryPart, ok := analysisQueryPart(analysis, partIndex); ok && readingClausesWouldReorder(part.ReadingClauses, queryPart.Regions) {
+				return true
+			}
+		}
+
+		if finalPart := multiPart.SinglePartQuery; finalPart != nil {
+			if queryPart, ok := analysisQueryPart(analysis, len(multiPart.Parts)); ok {
+				return readingClausesWouldReorder(finalPart.ReadingClauses, queryPart.Regions)
+			}
+		}
+
+		return false
+	}
+
+	if singlePart := query.SingleQuery.SinglePartQuery; singlePart != nil {
+		if queryPart, ok := analysisQueryPart(analysis, 0); ok {
+			return readingClausesWouldReorder(singlePart.ReadingClauses, queryPart.Regions)
+		}
+	}
+
+	return false
 }
 
 type reorderCandidate struct {
@@ -92,9 +134,22 @@ func reorderReadingClauses(readingClauses []*cypher.ReadingClause, regions []Reg
 	return applied
 }
 
+func readingClausesWouldReorder(readingClauses []*cypher.ReadingClause, regions []Region) bool {
+	for _, region := range regions {
+		if region.StartClause < 0 || region.EndClause >= len(readingClauses) || region.StartClause >= region.EndClause {
+			continue
+		}
+
+		if reorderRegionWouldApply(readingClauses[region.StartClause:region.EndClause+1], declaredBeforeClause(readingClauses, region.StartClause)) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func reorderRegion(regionClauses []*cypher.ReadingClause, declaredBeforeRegion map[string]struct{}) bool {
 	candidates := reorderCandidates(regionClauses, declaredBeforeRegion)
-
 	reordered := reorderCandidateSegments(candidates, declaredBeforeRegion)
 
 	var applied bool
@@ -106,6 +161,19 @@ func reorderRegion(regionClauses []*cypher.ReadingClause, declaredBeforeRegion m
 	}
 
 	return applied
+}
+
+func reorderRegionWouldApply(regionClauses []*cypher.ReadingClause, declaredBeforeRegion map[string]struct{}) bool {
+	candidates := reorderCandidates(regionClauses, declaredBeforeRegion)
+	reordered := reorderCandidateSegments(candidates, declaredBeforeRegion)
+
+	for idx, candidate := range reordered {
+		if regionClauses[idx] != candidate.clause {
+			return true
+		}
+	}
+
+	return false
 }
 
 func declaredBeforeClause(readingClauses []*cypher.ReadingClause, clauseIndex int) map[string]struct{} {

--- a/cypher/models/pgsql/translate/translator.go
+++ b/cypher/models/pgsql/translate/translator.go
@@ -17,18 +17,55 @@ import (
 // exercise translation output).
 const DefaultGraphID int32 = 0
 
+// OptimizerMode controls whether PostgreSQL-specific rewrites and lowering
+// decisions are applied during translation. Disabled mode remains a semantic
+// fallback: it translates the original AST with an empty lowering plan.
+type OptimizerMode string
+
+const (
+	OptimizerEnabled  OptimizerMode = "enabled"
+	OptimizerDisabled OptimizerMode = "disabled"
+)
+
+func (s OptimizerMode) Valid() bool {
+	return s == OptimizerEnabled || s == OptimizerDisabled
+}
+
+// Options configures a translation without changing the default Translate API.
+type Options struct {
+	OptimizerMode OptimizerMode
+}
+
+func DefaultOptions() Options {
+	return Options{
+		OptimizerMode: OptimizerEnabled,
+	}
+}
+
+func (s Options) normalized() (Options, error) {
+	if s.OptimizerMode == "" {
+		s.OptimizerMode = OptimizerEnabled
+	}
+	if !s.OptimizerMode.Valid() {
+		return Options{}, fmt.Errorf("unsupported PostgreSQL optimizer mode %q", s.OptimizerMode)
+	}
+
+	return s, nil
+}
+
 type Translator struct {
 	walk.Visitor[cypher.SyntaxNode]
 
-	ctx            context.Context
-	kindMapper     *contextAwareKindMapper
-	graphID        int32
-	parameters     map[string]any
-	translation    Result
-	treeTranslator *ExpressionTreeTranslator
-	query          *Query
-	scope          *Scope
-	unwindTargets  map[*cypher.Variable]struct{}
+	ctx              context.Context
+	kindMapper       *contextAwareKindMapper
+	graphID          int32
+	parameters       map[string]any
+	translation      Result
+	parameterSources map[string]string
+	treeTranslator   *ExpressionTreeTranslator
+	query            *Query
+	scope            *Scope
+	unwindTargets    map[*cypher.Variable]struct{}
 
 	collectIDMembershipAliases map[pgsql.Identifier]struct{}
 	collectIDProjectionDepth   int
@@ -63,6 +100,7 @@ func NewTranslator(ctx context.Context, kindMapper pgsql.KindMapper, parameters 
 
 	var (
 		translatedParameters = map[string]any{}
+		parameterSources     = map[string]string{}
 		ctxAwareKindMapper   = newContextAwareKindMapper(ctx, kindMapper, translatedParameters)
 	)
 
@@ -71,14 +109,15 @@ func NewTranslator(ctx context.Context, kindMapper pgsql.KindMapper, parameters 
 		translation: Result{
 			Parameters: translatedParameters,
 		},
-		ctx:            ctx,
-		kindMapper:     ctxAwareKindMapper,
-		graphID:        graphID,
-		parameters:     inputParameters,
-		treeTranslator: NewExpressionTreeTranslator(ctxAwareKindMapper),
-		query:          &Query{},
-		scope:          NewScope(),
-		unwindTargets:  map[*cypher.Variable]struct{}{},
+		ctx:              ctx,
+		kindMapper:       ctxAwareKindMapper,
+		graphID:          graphID,
+		parameters:       inputParameters,
+		parameterSources: parameterSources,
+		treeTranslator:   NewExpressionTreeTranslator(ctxAwareKindMapper),
+		query:            &Query{},
+		scope:            NewScope(),
+		unwindTargets:    map[*cypher.Variable]struct{}{},
 	}
 }
 
@@ -227,6 +266,7 @@ func (s *Translator) Enter(expression cypher.SyntaxNode) {
 				} else {
 					// Lift the parameter value into the parameters map
 					s.translation.Parameters[parameterBinding.Identifier.String()] = negotiatedValue
+					s.parameterSources[parameterBinding.Identifier.String()] = typedExpression.Symbol
 					parameterBinding.Parameter = newParameter
 				}
 
@@ -672,7 +712,9 @@ func (s *Translator) recordLowering(name string) {
 		}
 	}
 
-	s.translation.Optimization.Lowerings = append(s.translation.Optimization.Lowerings, optimize.LoweringDecision{Name: name})
+	s.translation.Optimization.Lowerings = append(s.translation.Optimization.Lowerings, optimize.LoweringDecision{
+		Name: name,
+	})
 }
 
 func (s *Translator) appliedLoweringCountSnapshot() map[string]int {
@@ -804,14 +846,46 @@ func skippedTraversalDirectionReason(plan optimize.LoweringPlan) string {
 }
 
 func Translate(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32) (Result, error) {
-	optimizedPlan, err := optimize.Optimize(cypherQuery)
+	return TranslateWithOptions(ctx, cypherQuery, kindMapper, parameters, graphID, DefaultOptions())
+}
+
+// TranslateWithOptions translates Cypher with an explicit optimizer policy.
+func TranslateWithOptions(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32, options Options) (Result, error) {
+	translation, _, err := translateWithOptions(ctx, cypherQuery, kindMapper, parameters, graphID, options, false)
+	return translation, err
+}
+
+// TranslateWithOptionsAndParameterSources translates Cypher and returns the
+// generated-parameter provenance required to safely rebind a cached result.
+// The input tree is borrowed: it is copied only if an optimizer rule mutates
+// it. This is intended for compilation code that owns the input tree.
+func TranslateWithOptionsAndParameterSources(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32, options Options) (Result, map[string]string, error) {
+	return translateWithOptions(ctx, cypherQuery, kindMapper, parameters, graphID, options, true)
+}
+
+func translateWithOptions(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32, options Options, borrowQuery bool) (Result, map[string]string, error) {
+	options, err := options.normalized()
 	if err != nil {
-		return Result{}, err
+		return Result{}, nil, err
+	}
+
+	var optimizedPlan optimize.Plan
+	if options.OptimizerMode == OptimizerEnabled {
+		if borrowQuery {
+			optimizedPlan, err = optimize.OptimizeBorrowed(cypherQuery)
+		} else {
+			optimizedPlan, err = optimize.Optimize(cypherQuery)
+		}
+		if err != nil {
+			return Result{}, nil, err
+		}
+	} else {
+		optimizedPlan.Query = cypherQuery
 	}
 
 	translator := NewTranslator(ctx, kindMapper, parameters, graphID)
 	if membershipAliases, err := collectIDMembershipAliases(optimizedPlan.Query); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	} else {
 		translator.collectIDMembershipAliases = membershipAliases
 	}
@@ -825,25 +899,25 @@ func Translate(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper
 	}
 
 	if translated, err := translator.translateCountStoreFastPath(optimizedPlan.Query, optimizedPlan.LoweringPlan); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	} else if translated {
 		translator.recordSkippedLowerings()
-		return translator.translation, nil
+		return translator.translation, translator.parameterSources, nil
 	}
 
 	if translated, err := translator.translateAggregateTraversalCount(optimizedPlan.Query, optimizedPlan.LoweringPlan); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	} else if translated {
 		translator.recordSkippedLowerings()
-		return translator.translation, nil
+		return translator.translation, translator.parameterSources, nil
 	}
 
 	if err := walk.Cypher(optimizedPlan.Query, translator); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	}
 
 	translator.recordSkippedLowerings()
-	return translator.translation, nil
+	return translator.translation, translator.parameterSources, nil
 }
 
 func decodeCypherStringLiteral(raw string) (string, error) {

--- a/cypher/models/pgsql/translate/translator_test.go
+++ b/cypher/models/pgsql/translate/translator_test.go
@@ -1,11 +1,66 @@
 package translate
 
 import (
+	"context"
 	"testing"
 
+	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/drivers/pg/pgutil"
+	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTranslationRecordsNamedParameterSources(t *testing.T) {
+	kindMapper := pgutil.NewInMemoryKindMapper()
+	kindMapper.Put(graph.StringKind("NodeKind1"))
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n:NodeKind1) WHERE n.name = $needle RETURN n`)
+	require.NoError(t, err)
+
+	translation, sources, err := TranslateWithOptionsAndParameterSources(context.Background(), query, kindMapper, map[string]any{"needle": "first"}, DefaultGraphID, DefaultOptions())
+	require.NoError(t, err)
+	require.Len(t, translation.Parameters, 1)
+	require.Len(t, sources, 1)
+	for generated := range translation.Parameters {
+		require.Equal(t, "needle", sources[generated])
+	}
+}
+
+func TestTranslateWithDisabledOptimizerUsesGenericPlan(t *testing.T) {
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
+	require.NoError(t, err)
+
+	translation, err := TranslateWithOptions(
+		context.Background(),
+		query,
+		pgutil.NewInMemoryKindMapper(),
+		nil,
+		DefaultGraphID,
+		Options{
+			OptimizerMode: OptimizerDisabled,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, translation.Optimization.Rules)
+	require.Nil(t, translation.Optimization.LoweringPlan)
+}
+
+func TestTranslateWithOptionsRejectsUnknownOptimizerMode(t *testing.T) {
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
+	require.NoError(t, err)
+
+	_, err = TranslateWithOptions(
+		context.Background(),
+		query,
+		pgutil.NewInMemoryKindMapper(),
+		nil,
+		DefaultGraphID,
+		Options{
+			OptimizerMode: "unknown",
+		},
+	)
+	require.ErrorContains(t, err, "unsupported PostgreSQL optimizer mode")
+}
 
 func TestDecodeCypherStringLiteral(t *testing.T) {
 	t.Parallel()

--- a/docs/postgresql_translation.md
+++ b/docs/postgresql_translation.md
@@ -59,6 +59,51 @@ Substring and suffix predicates are not promoted to blanket schema indexes. Post
 parameter/property forms that lower to helper functions remain outside the hard index-match contract until their
 lowering changes.
 
+## Translation Cache
+
+The PostgreSQL driver keeps one bounded, driver-wide compilation cache with a default capacity of 256 rendered SQL
+statements. It serves both `Transaction.Query` and the legacy programmatic query builder used by relationship and node
+queries. A warm builder hit avoids optimization, lowering-plan construction, PostgreSQL AST construction, and SQL
+rendering; it still builds the request AST, deterministically names its runtime parameters, renders the canonical
+Cypher cache identity, and assembles its debug comment.
+
+Entries are partitioned by the SHA-256 digest of trimmed Cypher text, target graph ID, sorted parameter names and PostgreSQL type shapes, a
+translation-key format/policy identity, and the schema generation. Parameter values are never retained or used as key
+material, and the cache key does not retain the source text. The retained data is limited to the SQL string and generated-parameter-to-Cypher-parameter source names;
+the cache does not retain caller maps or values, ASTs, contexts, transactions, connections, rows, or connection
+strings. Structural literals remain part of the cache identity. Generated parameters that cannot be reconstructed from
+request-local named sources, translation errors, disabled/closed cache state, and source text over 64 KiB bypass
+retention.
+
+Configure the bounded cache through the PostgreSQL driver constructor:
+
+```go
+database := pg.NewDriverWithOptions(0, pool, pg.DriverOptions{
+	TranslationCacheEntries: 0, // disables cache lookup and retention
+})
+```
+
+For a process-wide rollback, disable optimized translation directly and restore the prior state when appropriate:
+
+```go
+previous := pg.SetOptimizedTranslation(false)
+defer pg.SetOptimizedTranslation(previous)
+```
+
+When disabled, newly started PostgreSQL compilations bypass cache lookup and retention and translate the original AST
+with no PostgreSQL rewrite rules or lowering decisions. The setting is atomic and applies to every PostgreSQL driver in
+the process; each compilation snapshots it at entry, so already-running compilations continue with their selected path.
+Cached optimized entries remain dormant and are reusable after re-enabling. A zero cache capacity still runs optimized
+translation without retaining entries. The default remains optimized translation with a 256-entry cache.
+
+Concurrent cacheable misses for the same key share one translation. Waiters behind a failed, canceled, or non-cacheable
+build continue independently rather than serializing behind repeated failed work. Statistics are available through
+`(*pg.Driver).TranslationCacheStats()` and expose aggregate hits, build-leader misses, coalesced requests, bypasses,
+unoptimized compilations, insertions, evictions, binding/build failures, live size, capacity, and generation; they never
+expose query or value data. Successful schema assertions and kind refreshes advance the schema generation and discard completed entries.
+External schema or type changes cannot be detected automatically; recreate the driver/pool after those changes. Driver
+close retires the cache before the PostgreSQL pool closes.
+
 ## Validation Workflow
 
 Optimizer changes should include focused optimizer/lowering tests, SQL-shape translation tests, and backend-equivalent

--- a/drivers/pg/compiler.go
+++ b/drivers/pg/compiler.go
@@ -69,12 +69,21 @@ func (s *SchemaManager) compileRegularQuery(ctx context.Context, prepared prepar
 }
 
 func (s *SchemaManager) compile(ctx context.Context, source string, parameters map[string]any, graphID int32, parse func() (*cypher.RegularQuery, error)) (string, map[string]any, error) {
-	translationCache := s.translationCacheProvider.TranslationCache()
+	var (
+		translationCache   = s.translationCacheProvider.TranslationCache()
+		optimized          = OptimizedTranslationEnabled()
+		translationOptions = translate.Options{
+			OptimizerMode: translate.OptimizerDisabled,
+		}
+	)
+	if optimized {
+		translationOptions.OptimizerMode = translate.OptimizerEnabled
+	}
 
 	build := func() (string, translationCacheBuildResult, error) {
 		if regularQuery, err := parse(); err != nil {
 			return "", translationCacheBuildResult{}, err
-		} else if translated, parameterSources, err := translate.TranslateWithOptionsAndParameterSources(ctx, regularQuery, s, parameters, graphID, translate.DefaultOptions()); err != nil {
+		} else if translated, parameterSources, err := translate.TranslateWithOptionsAndParameterSources(ctx, regularQuery, s, parameters, graphID, translationOptions); err != nil {
 			return "", translationCacheBuildResult{}, err
 		} else if sqlQuery, err := translate.Translated(translated); err != nil {
 			return "", translationCacheBuildResult{}, err
@@ -84,6 +93,10 @@ func (s *SchemaManager) compile(ctx context.Context, source string, parameters m
 				parameterSources: parameterSources,
 			}, nil
 		}
+	}
+
+	if !optimized {
+		return translationCache.BuildUnoptimized(build)
 	}
 
 	key := translationCache.Key(source, graphID, parameters)

--- a/drivers/pg/compiler.go
+++ b/drivers/pg/compiler.go
@@ -1,0 +1,38 @@
+package pg
+
+import (
+	"context"
+	"strings"
+
+	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/pgsql/translate"
+)
+
+func (s *SchemaManager) compileText(ctx context.Context, source string, parameters map[string]any, graphID int32) (string, map[string]any, error) {
+	return s.compile(ctx, strings.TrimSpace(source), parameters, graphID, func() (*cypher.RegularQuery, error) {
+		return frontend.ParseCypher(frontend.NewContext(), source)
+	})
+}
+
+func (s *SchemaManager) compile(ctx context.Context, source string, parameters map[string]any, graphID int32, parse func() (*cypher.RegularQuery, error)) (string, map[string]any, error) {
+	translationCache := s.translationCacheProvider.TranslationCache()
+
+	build := func() (string, translationCacheBuildResult, error) {
+		if regularQuery, err := parse(); err != nil {
+			return "", translationCacheBuildResult{}, err
+		} else if translated, parameterSources, err := translate.TranslateWithOptionsAndParameterSources(ctx, regularQuery, s, parameters, graphID, translate.DefaultOptions()); err != nil {
+			return "", translationCacheBuildResult{}, err
+		} else if sqlQuery, err := translate.Translated(translated); err != nil {
+			return "", translationCacheBuildResult{}, err
+		} else {
+			return sqlQuery, translationCacheBuildResult{
+				parameters:       translated.Parameters,
+				parameterSources: parameterSources,
+			}, nil
+		}
+	}
+
+	key := translationCache.Key(source, graphID, parameters)
+	return translationCache.GetOrBuildContext(ctx, key, parameters, build)
+}

--- a/drivers/pg/compiler.go
+++ b/drivers/pg/compiler.go
@@ -6,12 +6,65 @@ import (
 
 	"github.com/specterops/dawgs/cypher/frontend"
 	"github.com/specterops/dawgs/cypher/models/cypher"
+	cypherFormat "github.com/specterops/dawgs/cypher/models/cypher/format"
 	"github.com/specterops/dawgs/cypher/models/pgsql/translate"
+	"github.com/specterops/dawgs/cypher/models/walk"
+	"github.com/specterops/dawgs/query"
 )
 
+const builderParameterPrefix = "__dawgs_builder_p"
+
+var builderCommentNewlines = strings.NewReplacer("\r\n", "\n-- ", "\r", "\n-- ", "\n", "\n-- ")
+
+// preparedRegularQuery holds a canonical view of a builder query. The source
+// AST remains untouched on cache hits; cold compilation creates its own copy.
+// Parameter values remain request-local and are never retained by the cache.
+type preparedRegularQuery struct {
+	query         *cypher.RegularQuery
+	source        string
+	commentSource string
+	parameters    map[string]any
+}
+
+func prepareRegularQuery(regularQuery *cypher.RegularQuery) (preparedRegularQuery, error) {
+	namer := query.NewParameterNamerWithPrefix(builderParameterPrefix)
+	if err := walk.Cypher(regularQuery, namer); err != nil {
+		return preparedRegularQuery{}, err
+	} else if source, err := cypherFormat.RegularQueryWithParameterSequence(regularQuery, false, namer.Symbols); err != nil {
+		return preparedRegularQuery{}, err
+	} else if commentSource, err := cypherFormat.RegularQueryWithParameterSequence(regularQuery, true, namer.Symbols); err != nil {
+		return preparedRegularQuery{}, err
+	} else {
+		return preparedRegularQuery{
+			query:         regularQuery,
+			source:        strings.TrimSpace(source),
+			commentSource: strings.TrimSpace(commentSource),
+			parameters:    namer.Parameters,
+		}, nil
+	}
+}
+
+func (s preparedRegularQuery) translationQuery() (*cypher.RegularQuery, error) {
+	owned := cypher.Copy(s.query)
+	rewriter := query.NewParameterRewriterWithPrefix(builderParameterPrefix)
+	if err := walk.Cypher(owned, rewriter); err != nil {
+		return nil, err
+	}
+
+	return owned, nil
+}
+
+// Both PostgreSQL Cypher entry points use these methods so a builder query and
+// its text equivalent share the same cache and cacheability rules.
 func (s *SchemaManager) compileText(ctx context.Context, source string, parameters map[string]any, graphID int32) (string, map[string]any, error) {
 	return s.compile(ctx, strings.TrimSpace(source), parameters, graphID, func() (*cypher.RegularQuery, error) {
 		return frontend.ParseCypher(frontend.NewContext(), source)
+	})
+}
+
+func (s *SchemaManager) compileRegularQuery(ctx context.Context, prepared preparedRegularQuery, graphID int32) (string, map[string]any, error) {
+	return s.compile(ctx, prepared.source, prepared.parameters, graphID, func() (*cypher.RegularQuery, error) {
+		return prepared.translationQuery()
 	})
 }
 
@@ -35,4 +88,8 @@ func (s *SchemaManager) compile(ctx context.Context, source string, parameters m
 
 	key := translationCache.Key(source, graphID, parameters)
 	return translationCache.GetOrBuildContext(ctx, key, parameters, build)
+}
+
+func commentRegularQuery(source, sql string) string {
+	return "-- " + builderCommentNewlines.Replace(source) + "\n" + sql
 }

--- a/drivers/pg/compiler_test.go
+++ b/drivers/pg/compiler_test.go
@@ -1,0 +1,446 @@
+package pg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareRegularQueryUsesStableNamesAndDoesNotMutateBuilder(t *testing.T) {
+	firstBuilder := query.NewBuilder(nil)
+	firstBuilder.Apply(
+		query.Where(query.Equals(query.NodeProperty("objectid"), graph.ID(1))),
+		query.Returning(query.Node()),
+	)
+
+	first, err := firstBuilder.Build(false)
+	require.NoError(t, err)
+
+	firstPrepared, err := prepareRegularQuery(first)
+	require.NoError(t, err)
+	require.Same(t, first, firstPrepared.query)
+
+	secondBuilder := query.NewBuilder(nil)
+	secondBuilder.Apply(
+		query.Where(query.Equals(query.NodeProperty("objectid"), graph.ID(2))),
+		query.Returning(query.Node()),
+	)
+
+	second, err := secondBuilder.Build(false)
+	require.NoError(t, err)
+
+	secondPrepared, err := prepareRegularQuery(second)
+	require.NoError(t, err)
+
+	require.Equal(t, firstPrepared.source, secondPrepared.source)
+	require.Equal(t, map[string]any{
+		builderParameterPrefix + "0": graph.ID(1),
+	}, firstPrepared.parameters)
+	require.Equal(t, map[string]any{
+		builderParameterPrefix + "0": graph.ID(2),
+	}, secondPrepared.parameters)
+	require.NotContains(t, firstPrepared.source, "1")
+	require.NotContains(t, secondPrepared.source, "2")
+
+	// Re-preparing the original builder query proves that preparation did not
+	// leak request-local generated names into it.
+	preparedAgain, err := prepareRegularQuery(first)
+	require.NoError(t, err)
+	require.Equal(t, firstPrepared.source, preparedAgain.source)
+}
+
+func TestPrepareRegularQueryRedactsLiteralsInSQLComments(t *testing.T) {
+	builder := query.NewBuilder(nil)
+	builder.Apply(query.Returning(query.Literal("sensitive-value")))
+
+	regularQuery, err := builder.Build(false)
+	require.NoError(t, err)
+	prepared, err := prepareRegularQuery(regularQuery)
+	require.NoError(t, err)
+	require.Contains(t, prepared.source, "sensitive-value")
+	require.NotContains(t, prepared.commentSource, "sensitive-value")
+	require.Contains(t, prepared.commentSource, "$STRIPPED")
+
+	commented := commentRegularQuery(prepared.commentSource, "select 1")
+	require.NotContains(t, commented, "sensitive-value")
+	require.Contains(t, commented, "$STRIPPED")
+}
+
+func TestBuilderPreparedQueriesShareTranslationCacheKey(t *testing.T) {
+	cache := newTranslationCache(1)
+	first := preparedRegularQuery{
+		source: "MATCH (n) WHERE n.id = $__dawgs_builder_p0 RETURN n",
+		parameters: map[string]any{
+			builderParameterPrefix + "0": graph.ID(1),
+		},
+	}
+	second := preparedRegularQuery{
+		source: first.source,
+		parameters: map[string]any{
+			builderParameterPrefix + "0": graph.ID(2),
+		},
+	}
+	key := cache.Key(first.source, 1, first.parameters)
+
+	_, bindings, err := cache.GetOrBuild(key, first.parameters, cacheableBuild(
+		"select @p0",
+		map[string]any{
+			"p0": uint64(1),
+		},
+		map[string]string{
+			"p0": builderParameterPrefix + "0",
+		},
+	))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"p0": uint64(1),
+	}, bindings)
+
+	builds := 0
+	_, bindings, err = cache.GetOrBuild(cache.Key(second.source, 1, second.parameters), second.parameters, func() (string, translationCacheBuildResult, error) {
+		builds++
+		return "", translationCacheBuildResult{}, nil
+	})
+	require.NoError(t, err)
+	require.Zero(t, builds)
+	require.Equal(t, map[string]any{
+		"p0": uint64(2),
+	}, bindings)
+}
+
+func buildPreparedNodeLookup(t *testing.T, id graph.ID) preparedRegularQuery {
+	t.Helper()
+	builder := query.NewBuilder(nil)
+	builder.Apply(
+		query.Where(query.Equals(query.NodeProperty("objectid"), id)),
+		query.Returning(query.Node()),
+	)
+	regularQuery, err := builder.Build(false)
+	require.NoError(t, err)
+	prepared, err := prepareRegularQuery(regularQuery)
+	require.NoError(t, err)
+	return prepared
+}
+
+func TestCompileRegularQueryCachesBuilderShapeAndRebindsValues(t *testing.T) {
+	setOptimizedTranslationForTest(t, true)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 2,
+	})
+	first := buildPreparedNodeLookup(t, graph.ID(1))
+	second := buildPreparedNodeLookup(t, graph.ID(2))
+
+	firstSQL, firstBindings, err := manager.compileRegularQuery(context.Background(), first, 7)
+	require.NoError(t, err)
+	secondSQL, secondBindings, err := manager.compileRegularQuery(context.Background(), second, 7)
+	require.NoError(t, err)
+
+	require.Equal(t, firstSQL, secondSQL)
+	require.NotEqual(t, firstBindings, secondBindings)
+	require.Len(t, firstBindings, 1)
+	require.Len(t, secondBindings, 1)
+	for name, firstValue := range firstBindings {
+		require.Equal(t, uint64(1), firstValue)
+		require.Equal(t, uint64(2), secondBindings[name])
+	}
+	stats := manager.translationCache.Stats()
+	require.Equal(t, int64(1), stats.Misses)
+	require.Equal(t, int64(1), stats.Hits)
+	require.Equal(t, int64(1), stats.Insertions)
+}
+
+func compilePreparedBuilderQuery(t *testing.T, builder *query.Builder) preparedRegularQuery {
+	t.Helper()
+
+	regularQuery, err := builder.Build(false)
+	require.NoError(t, err)
+	prepared, err := prepareRegularQuery(regularQuery)
+	require.NoError(t, err)
+	return prepared
+}
+
+// requireWarmBindingsMatchCold compiles one builder request to populate a cache,
+// then verifies that a same-shape request receives the exact bindings it would
+// have received from a fresh translation. This protects the complete builder
+// preparation -> cache -> translation path rather than only cache internals.
+func requireWarmBindingsMatchCold(t *testing.T, first, second preparedRegularQuery) {
+	t.Helper()
+	setOptimizedTranslationForTest(t, true)
+
+	warmManager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 8,
+	})
+	coldManager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 0,
+	})
+
+	firstSQL, firstBindings, err := warmManager.compileRegularQuery(context.Background(), first, 7)
+	require.NoError(t, err)
+	warmSQL, warmBindings, err := warmManager.compileRegularQuery(context.Background(), second, 7)
+	require.NoError(t, err)
+	coldSQL, coldBindings, err := coldManager.compileRegularQuery(context.Background(), second, 7)
+	require.NoError(t, err)
+
+	require.Equal(t, first.source, second.source)
+	require.Equal(t, firstSQL, warmSQL)
+	require.Equal(t, coldSQL, warmSQL)
+	require.Equal(t, coldBindings, warmBindings)
+	require.NotEqual(t, firstBindings, warmBindings, "a cache hit must not retain the first request's values")
+	require.Equal(t, int64(1), warmManager.translationCache.Stats().Misses)
+	require.Equal(t, int64(1), warmManager.translationCache.Stats().Hits)
+}
+
+func TestCompileRegularQueryWarmBindingsMatchColdForMultipleParameters(t *testing.T) {
+	timestamp := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name   string
+		first  func() *query.Builder
+		second func() *query.Builder
+	}{
+		{
+			name: "nested scalar predicates preserve order",
+			first: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Where(query.And(
+					query.Equals(query.NodeProperty("id"), graph.ID(101)),
+					query.Or(
+						query.StringContains(query.NodeProperty("name"), "first-name"),
+						query.GreaterThan(query.NodeProperty("rank"), int64(303)),
+					),
+					query.Equals(query.NodeProperty("enabled"), true),
+				)), query.Returning(query.Node()))
+				return builder
+			},
+			second: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Where(query.And(
+					query.Equals(query.NodeProperty("id"), graph.ID(202)),
+					query.Or(
+						query.StringContains(query.NodeProperty("name"), "second-name"),
+						query.GreaterThan(query.NodeProperty("rank"), int64(404)),
+					),
+					query.Equals(query.NodeProperty("enabled"), false),
+				)), query.Returning(query.Node()))
+				return builder
+			},
+		},
+		{
+			name: "ID collections and temporal values",
+			first: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Where(query.And(
+					query.InIDs(query.Node(), graph.ID(1), graph.ID(3)),
+					query.Before(query.NodeProperty("seen"), timestamp),
+				)), query.Returning(query.Node()))
+				return builder
+			},
+			second: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Where(query.And(
+					query.InIDs(query.Node(), graph.ID(2), graph.ID(4), graph.ID(6)),
+					query.Before(query.NodeProperty("seen"), timestamp.Add(time.Hour)),
+				)), query.Returning(query.Node()))
+				return builder
+			},
+		},
+		{
+			name: "floating point values",
+			first: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Where(query.Equals(query.NodeProperty("score"), 1.25)), query.Returning(query.Node()))
+				return builder
+			},
+			second: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Where(query.Equals(query.NodeProperty("score"), 9.75)), query.Returning(query.Node()))
+				return builder
+			},
+		},
+		{
+			name: "map properties",
+			first: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Create(query.NodePattern(nil, query.Parameter(map[string]any{"name": "first", "rank": int64(1)}))))
+				return builder
+			},
+			second: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(query.Create(query.NodePattern(nil, query.Parameter(map[string]any{"name": "second", "rank": int64(2)}))))
+				return builder
+			},
+		},
+		{
+			name: "set values and filter values",
+			first: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(
+					query.Where(query.Equals(query.NodeProperty("id"), graph.ID(11))),
+					query.Updatef(func() graph.Criteria { return query.SetProperties(query.Node(), map[string]any{"value": "first"}) }),
+				)
+				return builder
+			},
+			second: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(
+					query.Where(query.Equals(query.NodeProperty("id"), graph.ID(22))),
+					query.Updatef(func() graph.Criteria { return query.SetProperties(query.Node(), map[string]any{"value": "second"}) }),
+				)
+				return builder
+			},
+		},
+		{
+			name: "relationship set values and filter values",
+			first: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(
+					query.Where(query.InIDs(query.Relationship(), graph.ID(31))),
+					query.Updatef(func() graph.Criteria {
+						return query.SetProperties(query.Relationship(), map[string]any{"value": "first"})
+					}),
+				)
+				return builder
+			},
+			second: func() *query.Builder {
+				builder := query.NewBuilder(nil)
+				builder.Apply(
+					query.Where(query.InIDs(query.Relationship(), graph.ID(32))),
+					query.Updatef(func() graph.Criteria {
+						return query.SetProperties(query.Relationship(), map[string]any{"value": "second"})
+					}),
+				)
+				return builder
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			first := compilePreparedBuilderQuery(t, testCase.first())
+			second := compilePreparedBuilderQuery(t, testCase.second())
+			requireWarmBindingsMatchCold(t, first, second)
+		})
+	}
+}
+
+func TestCompileRegularQueryPartitionsParameterTypesAndStructuralLiterals(t *testing.T) {
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 8,
+	})
+
+	stringBuilder := query.NewBuilder(nil)
+	stringBuilder.Apply(query.Where(query.Equals(query.NodeProperty("value"), "one")), query.Returning(query.Node()))
+	stringQuery := compilePreparedBuilderQuery(t, stringBuilder)
+	intBuilder := query.NewBuilder(nil)
+	intBuilder.Apply(query.Where(query.Equals(query.NodeProperty("value"), int64(1))), query.Returning(query.Node()))
+	intQuery := compilePreparedBuilderQuery(t, intBuilder)
+	require.Equal(t, stringQuery.source, intQuery.source)
+	require.NotEqual(t, manager.translationCache.Key(stringQuery.source, 7, stringQuery.parameters), manager.translationCache.Key(intQuery.source, 7, intQuery.parameters))
+
+	limitOne := query.NewBuilder(nil)
+	limitOne.Apply(query.Where(query.Equals(query.NodeProperty("value"), "one")), query.Limit(1), query.Returning(query.Node()))
+	limitTwo := query.NewBuilder(nil)
+	limitTwo.Apply(query.Where(query.Equals(query.NodeProperty("value"), "one")), query.Limit(2), query.Returning(query.Node()))
+	limitOneQuery := compilePreparedBuilderQuery(t, limitOne)
+	limitTwoQuery := compilePreparedBuilderQuery(t, limitTwo)
+	require.NotEqual(t, limitOneQuery.source, limitTwoQuery.source)
+	require.NotEqual(t, manager.translationCache.Key(limitOneQuery.source, 7, limitOneQuery.parameters), manager.translationCache.Key(limitTwoQuery.source, 7, limitTwoQuery.parameters))
+
+	emptyIDs := map[string]any{"ids": []graph.ID{}}
+	populatedIDs := map[string]any{"ids": []graph.ID{1, 2}}
+	strings := map[string]any{"ids": []string{"1", "2"}}
+	require.Equal(t, manager.translationCache.Key("RETURN $ids", 7, emptyIDs), manager.translationCache.Key("RETURN $ids", 7, populatedIDs))
+	require.NotEqual(t, manager.translationCache.Key("RETURN $ids", 7, populatedIDs), manager.translationCache.Key("RETURN $ids", 7, strings))
+}
+
+func TestPrepareRegularQueryRenamesExplicitAndRepeatedParameterSymbols(t *testing.T) {
+	build := func(value string) preparedRegularQuery {
+		parameter := cypher.NewParameter(builderParameterPrefix+"99", value)
+		builder := query.NewBuilder(nil)
+		builder.Apply(
+			query.Where(query.And(
+				query.Equals(query.NodeProperty("first"), parameter),
+				query.Equals(query.NodeProperty("second"), parameter),
+			)),
+			query.Returning(query.Node()),
+		)
+		return compilePreparedBuilderQuery(t, builder)
+	}
+
+	first := build("first")
+	second := build("second")
+	require.NotContains(t, first.source, builderParameterPrefix+"99")
+	require.Equal(t, first.source, second.source)
+	require.Equal(t, map[string]any{
+		builderParameterPrefix + "0": "first",
+		builderParameterPrefix + "1": "first",
+	}, first.parameters)
+	requireWarmBindingsMatchCold(t, first, second)
+}
+
+func TestCompileRegularQueryDisabledCacheDoesNotRetainTranslation(t *testing.T) {
+	setOptimizedTranslationForTest(t, true)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 0,
+	})
+
+	_, _, err := manager.compileRegularQuery(context.Background(), buildPreparedNodeLookup(t, graph.ID(1)), 7)
+	require.NoError(t, err)
+	_, _, err = manager.compileRegularQuery(context.Background(), buildPreparedNodeLookup(t, graph.ID(2)), 7)
+	require.NoError(t, err)
+	stats := manager.translationCache.Stats()
+	require.Zero(t, stats.Misses)
+	require.Zero(t, stats.Size)
+	require.Equal(t, int64(2), stats.Bypasses)
+}
+
+func TestCompileRegularQueryUnoptimizedBypassesAndPreservesWarmEntries(t *testing.T) {
+	setOptimizedTranslationForTest(t, true)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 2,
+	})
+
+	first := buildPreparedNodeLookup(t, graph.ID(1))
+	_, _, err := manager.compileRegularQuery(context.Background(), first, 7)
+	require.NoError(t, err)
+	warmStats := manager.translationCache.Stats()
+
+	setOptimizedTranslationForTest(t, false)
+	_, _, err = manager.compileRegularQuery(context.Background(), buildPreparedNodeLookup(t, graph.ID(2)), 7)
+	require.NoError(t, err)
+	disabledStats := manager.translationCache.Stats()
+	require.Equal(t, warmStats.Hits, disabledStats.Hits)
+	require.Equal(t, warmStats.Misses, disabledStats.Misses)
+	require.Equal(t, warmStats.Insertions, disabledStats.Insertions)
+	require.Equal(t, warmStats.Bypasses+1, disabledStats.Bypasses)
+	require.Equal(t, warmStats.UnoptimizedCompilations+1, disabledStats.UnoptimizedCompilations)
+
+	setOptimizedTranslationForTest(t, true)
+	_, _, err = manager.compileRegularQuery(context.Background(), buildPreparedNodeLookup(t, graph.ID(3)), 7)
+	require.NoError(t, err)
+	require.Equal(t, warmStats.Hits+1, manager.translationCache.Stats().Hits)
+}
+
+func TestCompileTextUnoptimizedBypassesCache(t *testing.T) {
+	setOptimizedTranslationForTest(t, true)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 2,
+	})
+
+	_, _, err := manager.compileText(context.Background(), "MATCH (n) RETURN n", nil, 7)
+	require.NoError(t, err)
+	warmStats := manager.translationCache.Stats()
+
+	setOptimizedTranslationForTest(t, false)
+	_, _, err = manager.compileText(context.Background(), "MATCH (n) RETURN n", nil, 7)
+	require.NoError(t, err)
+	disabledStats := manager.translationCache.Stats()
+	require.Equal(t, warmStats.Hits, disabledStats.Hits)
+	require.Equal(t, warmStats.Misses, disabledStats.Misses)
+	require.Equal(t, warmStats.Bypasses+1, disabledStats.Bypasses)
+	require.Equal(t, warmStats.UnoptimizedCompilations+1, disabledStats.UnoptimizedCompilations)
+}

--- a/drivers/pg/driver.go
+++ b/drivers/pg/driver.go
@@ -42,11 +42,38 @@ type Driver struct {
 	*SchemaManager
 }
 
+// DriverOptions configures driver-wide behavior. TranslationCacheEntries is a
+// count, not a per-connection setting; zero disables translation caching.
+type DriverOptions struct {
+	TranslationCacheEntries int
+}
+
+// DefaultDriverOptions returns the driver-wide PostgreSQL settings used by
+// NewDriver.
+func DefaultDriverOptions() DriverOptions {
+	return DriverOptions{
+		TranslationCacheEntries: translationCacheCapacity,
+	}
+}
+
 func NewDriver(graphQueryMemoryLimit size.Size, pool *pgxpool.Pool) *Driver {
+	return NewDriverWithOptions(graphQueryMemoryLimit, pool, DefaultDriverOptions())
+}
+
+// NewDriverWithOptions constructs a PostgreSQL driver with driver-wide options.
+func NewDriverWithOptions(graphQueryMemoryLimit size.Size, pool *pgxpool.Pool, options DriverOptions) *Driver {
+	options = normalizeDriverOptions(options)
 	return &Driver{
 		pool:          pool,
-		SchemaManager: NewSchemaManager(pool, graphQueryMemoryLimit),
+		SchemaManager: NewSchemaManagerWithOptions(pool, graphQueryMemoryLimit, options),
 	}
+}
+
+func normalizeDriverOptions(options DriverOptions) DriverOptions {
+	if options.TranslationCacheEntries < 0 {
+		options.TranslationCacheEntries = 0
+	}
+	return options
 }
 
 func (s *Driver) SetDefaultGraph(ctx context.Context, graphSchema graph.Graph) error {
@@ -96,8 +123,15 @@ func (s *Driver) BatchOperation(ctx context.Context, batchDelegate graph.BatchDe
 }
 
 func (s *Driver) Close(ctx context.Context) error {
+	s.translationCache.Close()
 	s.pool.Close()
 	return nil
+}
+
+// TranslationCacheStats returns aggregate PostgreSQL translation-cache
+// counters. It never exposes cached query text, SQL, or parameter data.
+func (s *Driver) TranslationCacheStats() TranslationCacheStats {
+	return s.translationCache.Stats()
 }
 
 func renderConfig(batchWriteSize int, pgxOptions pgx.TxOptions, userOptions []graph.TransactionOption) (*Config, error) {
@@ -175,7 +209,12 @@ func (s *Driver) RefreshKinds(ctx context.Context) error {
 
 	// Wipe this map to be rebuilt in the fetch call below
 	s.SchemaManager.kindIDsByKind = map[int16]graph.Kind{}
-	return s.SchemaManager.Fetch(ctx)
+	if err := s.SchemaManager.Fetch(ctx); err != nil {
+		return err
+	}
+
+	s.translationCache.Invalidate()
+	return nil
 }
 
 func (s *Driver) OptimizeStorage(ctx context.Context) error {

--- a/drivers/pg/manager.go
+++ b/drivers/pg/manager.go
@@ -33,17 +33,37 @@ func KindMapperFromGraphDatabase(graphDB graph.Database) (KindMapper, error) {
 }
 
 type SchemaManager struct {
-	defaultGraph          model.Graph
-	pool                  *pgxpool.Pool
-	hasDefaultGraph       bool
-	graphs                map[string]model.Graph
-	kindsByID             map[graph.Kind]int16
-	kindIDsByKind         map[int16]graph.Kind
-	lock                  *sync.RWMutex
-	graphQueryMemoryLimit size.Size
+	defaultGraph             model.Graph
+	pool                     *pgxpool.Pool
+	hasDefaultGraph          bool
+	graphs                   map[string]model.Graph
+	kindsByID                map[graph.Kind]int16
+	kindIDsByKind            map[int16]graph.Kind
+	lock                     *sync.RWMutex
+	graphQueryMemoryLimit    size.Size
+	translationCache         *translationCache
+	translationCacheProvider translationCacheProvider
 }
 
 func NewSchemaManager(pool *pgxpool.Pool, graphQueryMemoryLimit size.Size) *SchemaManager {
+	return NewSchemaManagerWithOptions(pool, graphQueryMemoryLimit, DefaultDriverOptions())
+}
+
+// NewSchemaManagerWithTranslationCache permits an application to disable the
+// compilation cache (zero), or to choose a bounded driver-wide entry capacity.
+// Negative values disable the cache.
+func NewSchemaManagerWithTranslationCache(pool *pgxpool.Pool, graphQueryMemoryLimit size.Size, translationCacheEntries int) *SchemaManager {
+	return NewSchemaManagerWithOptions(pool, graphQueryMemoryLimit, DriverOptions{
+		TranslationCacheEntries: translationCacheEntries,
+	})
+}
+
+// NewSchemaManagerWithOptions constructs the shared compilation service with
+// a bounded translation cache.
+func NewSchemaManagerWithOptions(pool *pgxpool.Pool, graphQueryMemoryLimit size.Size, options DriverOptions) *SchemaManager {
+	options = normalizeDriverOptions(options)
+	translationCache := newTranslationCache(options.TranslationCacheEntries)
+
 	return &SchemaManager{
 		pool:                  pool,
 		hasDefaultGraph:       false,
@@ -52,6 +72,10 @@ func NewSchemaManager(pool *pgxpool.Pool, graphQueryMemoryLimit size.Size) *Sche
 		kindIDsByKind:         map[int16]graph.Kind{},
 		lock:                  &sync.RWMutex{},
 		graphQueryMemoryLimit: graphQueryMemoryLimit,
+		translationCache:      translationCache,
+		translationCacheProvider: sharedTranslationCacheProvider{
+			cache: translationCache,
+		},
 	}
 }
 
@@ -406,7 +430,12 @@ func (s *SchemaManager) AssertSchema(ctx context.Context, schema graph.Schema) e
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	return s.WriteTransaction(ctx, func(tx graph.Transaction) error {
+	if err := s.WriteTransaction(ctx, func(tx graph.Transaction) error {
 		return s.assertSchema(tx, schema)
-	}, OptionSetQueryExecMode(pgx.QueryExecModeSimpleProtocol))
+	}, OptionSetQueryExecMode(pgx.QueryExecModeSimpleProtocol)); err != nil {
+		return err
+	}
+
+	s.translationCache.Invalidate()
+	return nil
 }

--- a/drivers/pg/optimized_translation.go
+++ b/drivers/pg/optimized_translation.go
@@ -1,0 +1,25 @@
+package pg
+
+import "sync/atomic"
+
+var optimizedTranslationEnabled atomic.Bool
+
+func init() {
+	optimizedTranslationEnabled.Store(true)
+}
+
+// SetOptimizedTranslation enables or disables optimized PostgreSQL Cypher
+// translation for the current process. It returns the previous setting.
+//
+// Disabling optimization bypasses the translation cache and uses the baseline
+// translation path for calls that begin after the setting changes. Existing
+// cached entries remain available if optimization is enabled again.
+func SetOptimizedTranslation(enabled bool) bool {
+	return optimizedTranslationEnabled.Swap(enabled)
+}
+
+// OptimizedTranslationEnabled reports whether PostgreSQL Cypher translation
+// uses optimization and the translation cache for newly started compilations.
+func OptimizedTranslationEnabled() bool {
+	return optimizedTranslationEnabled.Load()
+}

--- a/drivers/pg/optimized_translation_test.go
+++ b/drivers/pg/optimized_translation_test.go
@@ -1,0 +1,48 @@
+package pg
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setOptimizedTranslationForTest(t testing.TB, enabled bool) {
+	t.Helper()
+	previous := SetOptimizedTranslation(enabled)
+	t.Cleanup(func() {
+		SetOptimizedTranslation(previous)
+	})
+}
+
+func TestOptimizedTranslationSwitch(t *testing.T) {
+	setOptimizedTranslationForTest(t, true)
+	require.True(t, OptimizedTranslationEnabled())
+
+	previous := SetOptimizedTranslation(false)
+	require.True(t, previous)
+	require.False(t, OptimizedTranslationEnabled())
+
+	previous = SetOptimizedTranslation(true)
+	require.False(t, previous)
+	require.True(t, OptimizedTranslationEnabled())
+}
+
+func TestOptimizedTranslationSwitchConcurrentAccess(t *testing.T) {
+	setOptimizedTranslationForTest(t, true)
+	var group sync.WaitGroup
+	for index := range 16 {
+		group.Add(1)
+		go func(enabled bool) {
+			defer group.Done()
+			for range 100 {
+				SetOptimizedTranslation(enabled)
+				_ = OptimizedTranslationEnabled()
+			}
+		}(index%2 == 0)
+	}
+	group.Wait()
+
+	SetOptimizedTranslation(true)
+	require.True(t, OptimizedTranslationEnabled())
+}

--- a/drivers/pg/query.go
+++ b/drivers/pg/query.go
@@ -3,24 +3,21 @@ package pg
 import (
 	"context"
 
-	"github.com/specterops/dawgs/cypher/models/pgsql/translate"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/query"
 )
 
 type liveQuery struct {
 	ctx             context.Context
-	tx              graph.Transaction
-	kindMapper      KindMapper
+	tx              *transaction
 	graphIDResolver func() (int32, error)
 	queryBuilder    *query.Builder
 }
 
-func newLiveQuery(ctx context.Context, tx graph.Transaction, kindMapper KindMapper, graphIDResolver func() (int32, error)) liveQuery {
+func newLiveQuery(ctx context.Context, tx *transaction, graphIDResolver func() (int32, error)) liveQuery {
 	return liveQuery{
 		ctx:             ctx,
 		tx:              tx,
-		kindMapper:      kindMapper,
 		graphIDResolver: graphIDResolver,
 		queryBuilder:    query.NewBuilder(nil),
 	}
@@ -29,12 +26,14 @@ func newLiveQuery(ctx context.Context, tx graph.Transaction, kindMapper KindMapp
 func (s *liveQuery) runRegularQuery(allShortestPaths bool) graph.Result {
 	if regularQuery, err := s.queryBuilder.Build(allShortestPaths); err != nil {
 		return graph.NewErrorResult(err)
+	} else if prepared, err := prepareRegularQuery(regularQuery); err != nil {
+		return graph.NewErrorResult(err)
 	} else if graphID, err := s.graphIDResolver(); err != nil {
 		return graph.NewErrorResult(err)
-	} else if translation, err := translate.FromCypher(s.ctx, regularQuery, s.kindMapper, false, graphID); err != nil {
+	} else if sqlQuery, bindings, err := s.tx.schemaManager.compileRegularQuery(s.ctx, prepared, graphID); err != nil {
 		return graph.NewErrorResult(err)
 	} else {
-		return s.tx.Raw(translation.Statement, translation.Parameters)
+		return s.tx.Raw(commentRegularQuery(prepared.commentSource, sqlQuery), bindings)
 	}
 }
 

--- a/drivers/pg/relationship.go
+++ b/drivers/pg/relationship.go
@@ -52,11 +52,11 @@ func (s *relationshipQuery) Update(properties *graph.Properties) error {
 		var updateStatements []graph.Criteria
 
 		if modifiedProperties := properties.ModifiedProperties(); len(modifiedProperties) > 0 {
-			updateStatements = append(updateStatements, query.SetProperties(query.Node(), modifiedProperties))
+			updateStatements = append(updateStatements, query.SetProperties(query.Relationship(), modifiedProperties))
 		}
 
 		if deletedProperties := properties.DeletedProperties(); len(deletedProperties) > 0 {
-			updateStatements = append(updateStatements, query.DeleteProperties(query.Node(), deletedProperties...))
+			updateStatements = append(updateStatements, query.DeleteProperties(query.Relationship(), deletedProperties...))
 		}
 
 		return updateStatements

--- a/drivers/pg/transaction.go
+++ b/drivers/pg/transaction.go
@@ -180,7 +180,7 @@ func (s *transaction) UpdateNode(node *graph.Node) error {
 
 func (s *transaction) Nodes() graph.NodeQuery {
 	return &nodeQuery{
-		liveQuery: newLiveQuery(s.ctx, s, s.schemaManager, s.targetGraphID),
+		liveQuery: newLiveQuery(s.ctx, s, s.targetGraphID),
 	}
 }
 
@@ -258,7 +258,7 @@ func (s *transaction) UpdateRelationship(relationship *graph.Relationship) error
 
 func (s *transaction) Relationships() graph.RelationshipQuery {
 	return &relationshipQuery{
-		liveQuery: newLiveQuery(s.ctx, s, s.schemaManager, s.targetGraphID),
+		liveQuery: newLiveQuery(s.ctx, s, s.targetGraphID),
 	}
 }
 

--- a/drivers/pg/transaction.go
+++ b/drivers/pg/transaction.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/specterops/dawgs/cypher/models/pgsql"
-	"github.com/specterops/dawgs/cypher/models/pgsql/translate"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/specterops/dawgs/cypher/frontend"
 	"github.com/specterops/dawgs/drivers/pg/model"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/query"
@@ -275,16 +273,15 @@ func (s *transaction) query(query string, parameters map[string]any) (pgx.Rows, 
 }
 
 func (s *transaction) Query(query string, parameters map[string]any) graph.Result {
-	if parsedQuery, err := frontend.ParseCypher(frontend.NewContext(), query); err != nil {
-		return graph.NewErrorResult(err)
-	} else if graphTarget, err := s.getTargetGraph(); err != nil {
-		return graph.NewErrorResult(err)
-	} else if translated, err := translate.Translate(s.ctx, parsedQuery, s.schemaManager, parameters, graphTarget.ID); err != nil {
-		return graph.NewErrorResult(err)
-	} else if sqlQuery, err := translate.Translated(translated); err != nil {
+	if graphTarget, err := s.getTargetGraph(); err != nil {
 		return graph.NewErrorResult(err)
 	} else {
-		return s.Raw(sqlQuery, translated.Parameters)
+		sqlQuery, bindings, err := s.schemaManager.compileText(s.ctx, query, parameters, graphTarget.ID)
+		if err != nil {
+			return graph.NewErrorResult(err)
+		}
+
+		return s.Raw(sqlQuery, bindings)
 	}
 }
 

--- a/drivers/pg/translation_cache.go
+++ b/drivers/pg/translation_cache.go
@@ -1,0 +1,407 @@
+package pg
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/specterops/dawgs/cache"
+	"github.com/specterops/dawgs/cypher/models/pgsql"
+)
+
+const (
+	translationCacheCapacity  = 256
+	translationCacheKeyFormat = 3
+	maxCachedCypherBytes      = 64 * 1024
+	translationCachePolicy    = "compiler-v4:optimized"
+)
+
+type translationCacheKey struct {
+	format           uint8
+	queryDigest      [sha256.Size]byte
+	querySize        int
+	graphID          int32
+	parameterTypes   string
+	policy           string
+	schemaGeneration uint64
+}
+
+type translationCacheBuildResult struct {
+	parameters       map[string]any
+	parameterSources map[string]string
+}
+
+type translationCacheEntry struct {
+	sql              string
+	parameterSources map[string]string
+}
+
+type translationCacheCall struct {
+	done     chan struct{}
+	doneOnce sync.Once
+	reusable bool
+}
+
+func (s *translationCacheCall) finish(reusable bool) {
+	s.doneOnce.Do(func() {
+		s.reusable = reusable
+		close(s.done)
+	})
+}
+
+// TranslationCacheStats contains aggregate counters only. It intentionally
+// exposes no source text, SQL, parameter names, values, or connection data.
+type TranslationCacheStats struct {
+	Hits                    int64
+	Misses                  int64
+	Coalesced               int64
+	Bypasses                int64
+	Insertions              int64
+	Evictions               int64
+	BindingFailures         int64
+	BuildFailures           int64
+	UnoptimizedCompilations int64
+	Size                    int64
+	Capacity                int
+	Generation              uint64
+}
+
+type translationCache struct {
+	capacity int
+	policy   string
+	entries  cache.Cache[translationCacheKey, translationCacheEntry]
+
+	lock    sync.Mutex
+	pending map[translationCacheKey]*translationCacheCall
+	closed  bool
+
+	schemaGeneration        atomic.Uint64
+	hits                    atomic.Int64
+	misses                  atomic.Int64
+	coalesced               atomic.Int64
+	bypasses                atomic.Int64
+	insertions              atomic.Int64
+	evictions               atomic.Int64
+	bindingFailures         atomic.Int64
+	buildFailures           atomic.Int64
+	unoptimizedCompilations atomic.Int64
+}
+
+type translationCacheProvider interface {
+	TranslationCache() *translationCache
+}
+
+type sharedTranslationCacheProvider struct {
+	cache *translationCache
+}
+
+func (s sharedTranslationCacheProvider) TranslationCache() *translationCache {
+	return s.cache
+}
+
+func newTranslationCache(capacity int) *translationCache {
+	return newTranslationCacheWithPolicy(capacity, translationCachePolicy)
+}
+
+func newTranslationCacheWithPolicy(capacity int, policy string) *translationCache {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if policy == "" {
+		policy = translationCachePolicy
+	}
+
+	cacheInstance := &translationCache{
+		capacity: capacity,
+		policy:   policy,
+		pending:  map[translationCacheKey]*translationCacheCall{},
+	}
+	if capacity > 0 {
+		cacheInstance.entries = cache.NewSieve[translationCacheKey, translationCacheEntry](capacity)
+	}
+
+	return cacheInstance
+}
+
+func (s *translationCache) Key(query string, graphID int32, parameters map[string]any) translationCacheKey {
+	query = strings.TrimSpace(query)
+
+	return translationCacheKey{
+		format:           translationCacheKeyFormat,
+		queryDigest:      sha256.Sum256([]byte(query)),
+		querySize:        len(query),
+		graphID:          graphID,
+		parameterTypes:   parameterTypeShape(parameters),
+		policy:           s.policy,
+		schemaGeneration: s.schemaGeneration.Load(),
+	}
+}
+
+func parameterTypeShape(parameters map[string]any) string {
+	if len(parameters) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(parameters))
+	for name := range parameters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	shape := strings.Builder{}
+	for _, name := range names {
+		dataType, err := pgsql.ValueToDataType(parameters[name])
+		if err != nil {
+			dataType = pgsql.DataType("unsupported:" + stableTypeName(parameters[name]))
+		}
+
+		fmt.Fprintf(&shape, "%d:%s=%s;", len(name), name, dataType)
+	}
+
+	return shape.String()
+}
+
+func stableTypeName(value any) string {
+	if value == nil {
+		return "nil"
+	}
+
+	return reflect.TypeOf(value).String()
+}
+
+func (s *translationCache) GetOrBuild(key translationCacheKey, parameters map[string]any, build func() (string, translationCacheBuildResult, error)) (string, map[string]any, error) {
+	return s.GetOrBuildContext(context.Background(), key, parameters, build)
+}
+
+func (s *translationCache) GetOrBuildContext(ctx context.Context, key translationCacheKey, parameters map[string]any, build func() (string, translationCacheBuildResult, error)) (string, map[string]any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if key.querySize > maxCachedCypherBytes || s.capacity == 0 {
+		s.bypasses.Add(1)
+		return s.buildUncached(build)
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", nil, err
+		}
+
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			s.bypasses.Add(1)
+			return s.buildUncached(build)
+		}
+		if s.entries != nil {
+			if entry, found := s.entries.Get(key); found {
+				s.lock.Unlock()
+				bindings, err := bindCachedParameters(entry.parameterSources, parameters)
+				if err != nil {
+					s.bindingFailures.Add(1)
+					return "", nil, err
+				}
+				s.hits.Add(1)
+				return entry.sql, bindings, nil
+			}
+		}
+
+		if pending := s.pending[key]; pending != nil {
+			s.lock.Unlock()
+			select {
+			case <-pending.done:
+				s.coalesced.Add(1)
+				if !pending.reusable {
+					s.bypasses.Add(1)
+					return s.buildUncached(build)
+				}
+				continue
+
+			case <-ctx.Done():
+				return "", nil, ctx.Err()
+			}
+		}
+
+		pending := &translationCacheCall{
+			done: make(chan struct{}),
+		}
+		s.pending[key] = pending
+		s.misses.Add(1)
+		s.lock.Unlock()
+
+		sql, result, err, panicked := callTranslationBuild(build)
+		entry, cacheable := cacheableTranslation(sql, result, parameters, err)
+
+		s.lock.Lock()
+		currentGeneration := s.schemaGeneration.Load()
+		generationCurrent := key.schemaGeneration == currentGeneration
+		closed := s.closed
+		reusable := cacheable && generationCurrent && !closed && panicked == nil
+		if reusable {
+			if s.entries.Stats().Size() >= int64(s.capacity) {
+				s.evictions.Add(1)
+			}
+			s.entries.Put(cloneTranslationCacheKey(key), entry)
+			s.insertions.Add(1)
+		}
+		if s.pending[key] == pending {
+			delete(s.pending, key)
+		}
+		pending.finish(reusable)
+		s.lock.Unlock()
+
+		if panicked != nil {
+			panic(panicked)
+		}
+		if err != nil {
+			s.buildFailures.Add(1)
+			return "", nil, err
+		}
+		if !generationCurrent && !closed {
+			key.schemaGeneration = currentGeneration
+			continue
+		}
+		if closed || !cacheable {
+			s.bypasses.Add(1)
+			return sql, result.parameters, nil
+		}
+
+		return sql, result.parameters, nil
+	}
+}
+
+func callTranslationBuild(build func() (string, translationCacheBuildResult, error)) (sql string, result translationCacheBuildResult, err error, panicked any) {
+	defer func() {
+		panicked = recover()
+	}()
+
+	sql, result, err = build()
+	return sql, result, err, nil
+}
+
+func (s *translationCache) buildUncached(build func() (string, translationCacheBuildResult, error)) (string, map[string]any, error) {
+	sql, result, err, panicked := callTranslationBuild(build)
+	if panicked != nil {
+		panic(panicked)
+	}
+	if err != nil {
+		s.buildFailures.Add(1)
+		return "", nil, err
+	}
+
+	return sql, result.parameters, nil
+}
+
+func (s *translationCache) BuildUnoptimized(build func() (string, translationCacheBuildResult, error)) (string, map[string]any, error) {
+	s.unoptimizedCompilations.Add(1)
+	s.bypasses.Add(1)
+	return s.buildUncached(build)
+}
+
+func cloneTranslationCacheKey(key translationCacheKey) translationCacheKey {
+	key.parameterTypes = strings.Clone(key.parameterTypes)
+	key.policy = strings.Clone(key.policy)
+	return key
+}
+
+func cacheableTranslation(sql string, result translationCacheBuildResult, parameters map[string]any, err error) (translationCacheEntry, bool) {
+	if err != nil {
+		return translationCacheEntry{}, false
+	}
+	if len(result.parameters) != len(result.parameterSources) {
+		return translationCacheEntry{}, false
+	}
+
+	sources := make(map[string]string, len(result.parameterSources))
+	for generated := range result.parameters {
+		source, found := result.parameterSources[generated]
+		if !found {
+			return translationCacheEntry{}, false
+		}
+		if source == "" {
+			return translationCacheEntry{}, false
+		}
+		if _, found := parameters[source]; !found {
+			return translationCacheEntry{}, false
+		}
+		sources[strings.Clone(generated)] = strings.Clone(source)
+	}
+
+	return translationCacheEntry{
+		sql:              strings.Clone(sql),
+		parameterSources: sources,
+	}, true
+}
+
+func bindCachedParameters(sources map[string]string, parameters map[string]any) (map[string]any, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
+
+	bindings := make(map[string]any, len(sources))
+	for generated, source := range sources {
+		value, found := parameters[source]
+		if !found {
+			return nil, fmt.Errorf("missing value for Cypher parameter %q", source)
+		}
+		negotiated, err := pgsql.NegotiateValue(value)
+		if err != nil {
+			return nil, err
+		}
+		bindings[generated] = negotiated
+	}
+
+	return bindings, nil
+}
+
+func (s *translationCache) Invalidate() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.schemaGeneration.Add(1)
+	if !s.closed && s.capacity > 0 {
+		s.entries = cache.NewSieve[translationCacheKey, translationCacheEntry](s.capacity)
+	}
+}
+
+func (s *translationCache) Close() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.closed = true
+	s.entries = nil
+	for key, pending := range s.pending {
+		delete(s.pending, key)
+		pending.finish(false)
+	}
+}
+
+func (s *translationCache) Stats() TranslationCacheStats {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	var size int64
+	if s.entries != nil {
+		size = s.entries.Stats().Size()
+	}
+
+	return TranslationCacheStats{
+		Hits:                    s.hits.Load(),
+		Misses:                  s.misses.Load(),
+		Coalesced:               s.coalesced.Load(),
+		Bypasses:                s.bypasses.Load(),
+		Insertions:              s.insertions.Load(),
+		Evictions:               s.evictions.Load(),
+		BindingFailures:         s.bindingFailures.Load(),
+		BuildFailures:           s.buildFailures.Load(),
+		UnoptimizedCompilations: s.unoptimizedCompilations.Load(),
+		Size:                    size,
+		Capacity:                s.capacity,
+		Generation:              s.schemaGeneration.Load(),
+	}
+}

--- a/drivers/pg/translation_cache_benchmark_test.go
+++ b/drivers/pg/translation_cache_benchmark_test.go
@@ -1,0 +1,175 @@
+package pg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/cypher/models/pgsql/translate"
+	"github.com/specterops/dawgs/drivers/pg/pgutil"
+	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/query"
+)
+
+func benchmarkTranslationBuild(query string, parameters map[string]any) func() (string, translationCacheBuildResult, error) {
+	return func() (string, translationCacheBuildResult, error) {
+		parsedQuery, err := frontend.ParseCypher(frontend.NewContext(), query)
+		if err != nil {
+			return "", translationCacheBuildResult{}, err
+		}
+
+		kindMapper := pgutil.NewInMemoryKindMapper()
+		kindMapper.Put(graph.StringKind("NodeKind1"))
+		translation, parameterSources, err := translate.TranslateWithOptionsAndParameterSources(context.Background(), parsedQuery, kindMapper, parameters, translate.DefaultGraphID, translate.DefaultOptions())
+		if err != nil {
+			return "", translationCacheBuildResult{}, err
+		}
+
+		sql, err := translate.Translated(translation)
+		return sql, translationCacheBuildResult{
+			parameters:       translation.Parameters,
+			parameterSources: parameterSources,
+		}, err
+	}
+}
+
+func BenchmarkTranslationCacheUncached(b *testing.B) {
+	build := benchmarkTranslationBuild(`MATCH (n:NodeKind1) WHERE n.name = $name RETURN n`, map[string]any{"name": "first"})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, _, err := build(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTranslationCacheColdPopulation(b *testing.B) {
+	parameters := map[string]any{"name": "first"}
+	build := benchmarkTranslationBuild(`MATCH (n:NodeKind1) WHERE n.name = $name RETURN n`, parameters)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		translationCache := newTranslationCache(1)
+		if _, _, err := translationCache.GetOrBuild(translationCache.Key(`MATCH (n:NodeKind1) WHERE n.name = $name RETURN n`, 1, parameters), parameters, build); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTranslationCacheParameterizedHit(b *testing.B) {
+	parameters := map[string]any{"name": "first"}
+	query := `MATCH (n:NodeKind1) WHERE n.name = $name RETURN n`
+	translationCache := newTranslationCache(1)
+	key := translationCache.Key(query, 1, parameters)
+	build := benchmarkTranslationBuild(query, parameters)
+	if _, _, err := translationCache.GetOrBuild(key, parameters, build); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		parameters["name"] = "next"
+		if _, _, err := translationCache.GetOrBuild(translationCache.Key(query, 1, parameters), parameters, build); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTranslationCacheParameterlessHit(b *testing.B) {
+	query := `MATCH (n:NodeKind1) RETURN n`
+	translationCache := newTranslationCache(1)
+	key := translationCache.Key(query, 1, nil)
+	build := benchmarkTranslationBuild(query, nil)
+	if _, _, err := translationCache.GetOrBuild(key, nil, build); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, _, err := translationCache.GetOrBuild(key, nil, build); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkPreparedFetchStartNodes(b *testing.B, id graph.ID) preparedRegularQuery {
+	b.Helper()
+	builder := query.NewBuilder(nil)
+	builder.Apply(
+		query.Where(query.Equals(query.StartProperty("objectid"), id)),
+		query.Returning(query.Relationship(), query.Start()),
+	)
+	regularQuery, err := builder.Build(false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	prepared, err := prepareRegularQuery(regularQuery)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return prepared
+}
+
+func BenchmarkBuilderFetchStartNodesOptimizedCacheDisabled(b *testing.B) {
+	setOptimizedTranslationForTest(b, true)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 0,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := range b.N {
+		if _, _, err := manager.compileRegularQuery(context.Background(), benchmarkPreparedFetchStartNodes(b, graph.ID(index+1)), translate.DefaultGraphID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuilderFetchStartNodesColdPopulation(b *testing.B) {
+	setOptimizedTranslationForTest(b, true)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := range b.N {
+		manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+			TranslationCacheEntries: 1,
+		})
+		if _, _, err := manager.compileRegularQuery(context.Background(), benchmarkPreparedFetchStartNodes(b, graph.ID(index+1)), translate.DefaultGraphID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuilderFetchStartNodesWarmHit(b *testing.B) {
+	setOptimizedTranslationForTest(b, true)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 1,
+	})
+	if _, _, err := manager.compileRegularQuery(context.Background(), benchmarkPreparedFetchStartNodes(b, graph.ID(1)), translate.DefaultGraphID); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := range b.N {
+		if _, _, err := manager.compileRegularQuery(context.Background(), benchmarkPreparedFetchStartNodes(b, graph.ID(index+2)), translate.DefaultGraphID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuilderFetchStartNodesUnoptimized(b *testing.B) {
+	setOptimizedTranslationForTest(b, false)
+	manager := NewSchemaManagerWithOptions(nil, 0, DriverOptions{
+		TranslationCacheEntries: 1,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := range b.N {
+		if _, _, err := manager.compileRegularQuery(context.Background(), benchmarkPreparedFetchStartNodes(b, graph.ID(index+1)), translate.DefaultGraphID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/drivers/pg/translation_cache_test.go
+++ b/drivers/pg/translation_cache_test.go
@@ -1,0 +1,450 @@
+package pg
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+func cacheableBuild(sql string, parameters map[string]any, sources map[string]string) func() (string, translationCacheBuildResult, error) {
+	return func() (string, translationCacheBuildResult, error) {
+		return sql, translationCacheBuildResult{
+			parameters:       parameters,
+			parameterSources: sources,
+		}, nil
+	}
+}
+
+func TestTranslationCacheRebindsCurrentValues(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	firstParameters := map[string]any{"needle": graph.ID(1)}
+	key := translationCache.Key("RETURN $needle", 7, firstParameters)
+
+	_, bindings, err := translationCache.GetOrBuild(key, firstParameters, cacheableBuild("select @p0", map[string]any{"p0": uint64(1)}, map[string]string{"p0": "needle"}))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"p0": uint64(1)}, bindings)
+
+	secondParameters := map[string]any{"needle": graph.ID(2)}
+	builds := 0
+	_, bindings, err = translationCache.GetOrBuild(translationCache.Key("RETURN $needle", 7, secondParameters), secondParameters, func() (string, translationCacheBuildResult, error) {
+		builds++
+		return "", translationCacheBuildResult{}, nil
+	})
+	require.NoError(t, err)
+	require.Zero(t, builds)
+	require.Equal(t, map[string]any{"p0": uint64(2)}, bindings)
+	require.Equal(t, int64(1), translationCache.Stats().Hits)
+}
+
+func TestTranslationCachePartitionsKeysAndBypassesUnsafeResults(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+
+	require.NotEqual(t, key, translationCache.Key("RETURN $other", 1, parameters))
+	require.NotEqual(t, key, translationCache.Key("RETURN $value", 2, parameters))
+	require.NotEqual(t, key, translationCache.Key("RETURN $value", 1, map[string]any{"other": int64(1)}))
+	require.NotEqual(t, key, translationCache.Key("RETURN $value", 1, map[string]any{"value": "1"}))
+	translationCache.Invalidate()
+	require.NotEqual(t, key, translationCache.Key("RETURN $value", 1, parameters))
+	key = translationCache.Key("RETURN $value", 1, parameters)
+
+	builds := 0
+	for range 2 {
+		_, _, err := translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+			builds++
+			return "select @p0", translationCacheBuildResult{
+				parameters: map[string]any{"p0": int64(1)},
+			}, nil
+		})
+		require.NoError(t, err)
+	}
+	require.Equal(t, 2, builds, "a parameter without provenance must not be retained")
+}
+
+func TestTranslationCacheKeyUsesDigestWithoutSourceText(t *testing.T) {
+	translationCache := newTranslationCache(1)
+	key := translationCache.Key("RETURN $secret // customer-value", 1, map[string]any{"secret": "value"})
+	other := translationCache.Key("RETURN $other", 1, map[string]any{"secret": "value"})
+
+	require.Equal(t, len("RETURN $secret // customer-value"), key.querySize)
+	require.NotEqual(t, key.queryDigest, other.queryDigest)
+}
+
+func TestTranslationCacheBypassesOversizedSource(t *testing.T) {
+	translationCache := newTranslationCache(1)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key(strings.Repeat("x", maxCachedCypherBytes+1), 1, parameters)
+	builds := 0
+
+	for range 2 {
+		_, _, err := translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+			builds++
+			return "select @p0", translationCacheBuildResult{
+				parameters:       map[string]any{"p0": int64(1)},
+				parameterSources: map[string]string{"p0": "value"},
+			}, nil
+		})
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 2, builds)
+	require.Equal(t, int64(2), translationCache.Stats().Bypasses)
+}
+
+func TestCacheableTranslationRequiresExactParameterProvenance(t *testing.T) {
+	_, cacheable := cacheableTranslation("select @p0", translationCacheBuildResult{
+		parameters:       map[string]any{"p0": int64(1)},
+		parameterSources: map[string]string{"p1": "value"},
+	}, map[string]any{"value": int64(1)}, nil)
+
+	require.False(t, cacheable)
+}
+
+func TestTranslationCacheReportsEviction(t *testing.T) {
+	translationCache := newTranslationCache(1)
+	parameters := map[string]any{"value": int64(1)}
+
+	_, _, err := translationCache.GetOrBuild(translationCache.Key("RETURN $value", 1, parameters), parameters, cacheableBuild("select @p0", map[string]any{"p0": int64(1)}, map[string]string{"p0": "value"}))
+	require.NoError(t, err)
+	_, _, err = translationCache.GetOrBuild(translationCache.Key("RETURN $value + 1", 1, parameters), parameters, cacheableBuild("select @p0", map[string]any{"p0": int64(1)}, map[string]string{"p0": "value"}))
+	require.NoError(t, err)
+
+	stats := translationCache.Stats()
+	require.Equal(t, int64(1), stats.Evictions)
+	require.Equal(t, int64(1), stats.Size)
+}
+
+func TestTranslationCacheCoalescesCacheableMisses(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	errs := make(chan error, 8)
+	var builds atomic.Int64
+	var group sync.WaitGroup
+
+	for range 8 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, _, err := translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+				if builds.Add(1) == 1 {
+					close(started)
+					<-release
+				}
+				return "select @p0", translationCacheBuildResult{
+					parameters:       map[string]any{"p0": int64(1)},
+					parameterSources: map[string]string{"p0": "value"},
+				}, nil
+			})
+			errs <- err
+		}()
+	}
+
+	<-started
+	time.Sleep(10 * time.Millisecond)
+	close(release)
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(1), builds.Load())
+}
+
+func TestTranslationCacheCoalescedRequestsBindTheirOwnValues(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	source := "RETURN $value"
+	leaderParameters := map[string]any{"value": graph.ID(1)}
+	key := translationCache.Key(source, 1, leaderParameters)
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	type result struct {
+		bindings map[string]any
+		err      error
+	}
+	leaderDone := make(chan result, 1)
+	go func() {
+		_, bindings, err := translationCache.GetOrBuild(key, leaderParameters, func() (string, translationCacheBuildResult, error) {
+			close(started)
+			<-release
+			return "select @p0", translationCacheBuildResult{
+				parameters:       map[string]any{"p0": uint64(1)},
+				parameterSources: map[string]string{"p0": "value"},
+			}, nil
+		})
+		leaderDone <- result{
+			bindings: bindings,
+			err:      err,
+		}
+	}()
+
+	<-started
+	values := []graph.ID{2, 3, 4, 5}
+	waiters := make(chan result, len(values))
+	for _, value := range values {
+		value := value
+		go func() {
+			parameters := map[string]any{"value": value}
+			_, bindings, err := translationCache.GetOrBuild(translationCache.Key(source, 1, parameters), parameters, func() (string, translationCacheBuildResult, error) {
+				return "", translationCacheBuildResult{}, errors.New("coalesced request unexpectedly rebuilt the translation")
+			})
+			waiters <- result{
+				bindings: bindings,
+				err:      err,
+			}
+		}()
+	}
+
+	close(release)
+	leader := <-leaderDone
+	require.NoError(t, leader.err)
+	require.Equal(t, map[string]any{"p0": uint64(1)}, leader.bindings)
+
+	seen := map[uint64]struct{}{}
+	for range values {
+		waiter := <-waiters
+		require.NoError(t, waiter.err)
+		value, ok := waiter.bindings["p0"].(uint64)
+		require.True(t, ok)
+		seen[value] = struct{}{}
+	}
+	require.Equal(t, map[uint64]struct{}{2: {}, 3: {}, 4: {}, 5: {}}, seen)
+}
+
+func TestTranslationCacheWaiterCancellationDoesNotInterruptLeader(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": graph.ID(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	leaderDone := make(chan error, 1)
+
+	go func() {
+		_, _, err := translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+			close(started)
+			<-release
+			return "select @p0", translationCacheBuildResult{
+				parameters:       map[string]any{"p0": uint64(1)},
+				parameterSources: map[string]string{"p0": "value"},
+			}, nil
+		})
+		leaderDone <- err
+	}()
+
+	<-started
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := translationCache.GetOrBuildContext(ctx, key, parameters, func() (string, translationCacheBuildResult, error) {
+		return "", translationCacheBuildResult{}, errors.New("cancelled request unexpectedly rebuilt the translation")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+
+	close(release)
+	require.NoError(t, <-leaderDone)
+	_, bindings, err := translationCache.GetOrBuild(key, map[string]any{"value": graph.ID(2)}, func() (string, translationCacheBuildResult, error) {
+		return "", translationCacheBuildResult{}, errors.New("completed leader did not publish a reusable translation")
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"p0": uint64(2)}, bindings)
+}
+
+func TestTranslationCacheParameterlessHitAndClose(t *testing.T) {
+	translationCache := newTranslationCache(1)
+	key := translationCache.Key("RETURN 1", 1, nil)
+	build := cacheableBuild("select 1", map[string]any{}, map[string]string{})
+
+	_, bindings, err := translationCache.GetOrBuild(key, nil, build)
+	require.NoError(t, err)
+	require.Empty(t, bindings)
+	_, bindings, err = translationCache.GetOrBuild(key, nil, build)
+	require.NoError(t, err)
+	require.Nil(t, bindings)
+
+	translationCache.Close()
+	builds := 0
+	_, _, err = translationCache.GetOrBuild(key, nil, func() (string, translationCacheBuildResult, error) {
+		builds++
+		return "select 1", translationCacheBuildResult{}, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, builds)
+}
+
+func TestTranslationCacheNonCacheableWaitersBuildIndependently(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+	leaderStarted := make(chan struct{})
+	releaseLeader := make(chan struct{})
+	uncachedStarted := make(chan struct{}, 7)
+	releaseUncached := make(chan struct{})
+	errs := make(chan error, 8)
+	var builds atomic.Int64
+	var group sync.WaitGroup
+
+	for range 8 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, _, err := translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+				if builds.Add(1) == 1 {
+					close(leaderStarted)
+					<-releaseLeader
+				} else {
+					uncachedStarted <- struct{}{}
+					<-releaseUncached
+				}
+
+				return "select @p0", translationCacheBuildResult{
+					parameters: map[string]any{"p0": int64(1)},
+				}, nil
+			})
+			errs <- err
+		}()
+	}
+
+	<-leaderStarted
+	time.Sleep(10 * time.Millisecond)
+	close(releaseLeader)
+	for range 7 {
+		select {
+		case <-uncachedStarted:
+		case <-time.After(time.Second):
+			t.Fatal("non-cacheable waiters were serialized")
+		}
+	}
+	close(releaseUncached)
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(8), builds.Load())
+}
+
+func TestTranslationCachePanicReleasesWaiters(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+	leaderStarted := make(chan struct{})
+	releaseLeader := make(chan struct{})
+	leaderDone := make(chan struct{})
+	panicValue := make(chan any, 1)
+	waiterDone := make(chan error, 1)
+
+	go func() {
+		defer close(leaderDone)
+		defer func() {
+			panicValue <- recover()
+		}()
+		_, _, _ = translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+			close(leaderStarted)
+			<-releaseLeader
+			panic("boom")
+		})
+	}()
+
+	<-leaderStarted
+	go func() {
+		_, _, err := translationCache.GetOrBuild(key, parameters, cacheableBuild(
+			"select @p0",
+			map[string]any{"p0": int64(1)},
+			map[string]string{"p0": "value"},
+		))
+		waiterDone <- err
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	close(releaseLeader)
+	<-leaderDone
+	require.Equal(t, "boom", <-panicValue)
+	select {
+	case err := <-waiterDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("panic left a cache waiter blocked")
+	}
+}
+
+func TestTranslationCacheCloseReleasesWaiters(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+	leaderStarted := make(chan struct{})
+	releaseLeader := make(chan struct{})
+	leaderDone := make(chan struct{})
+	waiterDone := make(chan error, 1)
+
+	go func() {
+		defer close(leaderDone)
+		_, _, _ = translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+			close(leaderStarted)
+			<-releaseLeader
+			return "select @p0", translationCacheBuildResult{}, nil
+		})
+	}()
+
+	<-leaderStarted
+	go func() {
+		_, _, err := translationCache.GetOrBuildContext(context.Background(), key, parameters, cacheableBuild(
+			"select @p0",
+			map[string]any{"p0": int64(1)},
+			map[string]string{"p0": "value"},
+		))
+		waiterDone <- err
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	translationCache.Close()
+	select {
+	case err := <-waiterDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("cache close left a waiter blocked")
+	}
+	close(releaseLeader)
+	<-leaderDone
+}
+
+func TestTranslationCacheInvalidationDoesNotPublishStaleBuild(t *testing.T) {
+	translationCache := newTranslationCache(2)
+	parameters := map[string]any{"value": int64(1)}
+	key := translationCache.Key("RETURN $value", 1, parameters)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var builds atomic.Int64
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := translationCache.GetOrBuild(key, parameters, func() (string, translationCacheBuildResult, error) {
+			if builds.Add(1) == 1 {
+				close(started)
+				<-release
+			}
+			return "select @p0", translationCacheBuildResult{
+				parameters:       map[string]any{"p0": int64(1)},
+				parameterSources: map[string]string{"p0": "value"},
+			}, nil
+		})
+		done <- err
+	}()
+
+	<-started
+	translationCache.Invalidate()
+	close(release)
+	require.NoError(t, <-done)
+	require.Equal(t, int64(2), builds.Load())
+	require.Equal(t, int64(1), translationCache.Stats().Size)
+	require.Equal(t, uint64(1), translationCache.Stats().Generation)
+}

--- a/integration/pgsql_translation_cache_test.go
+++ b/integration/pgsql_translation_cache_test.go
@@ -1,0 +1,389 @@
+//go:build manual_integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/specterops/dawgs/drivers/pg"
+	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/ops"
+	"github.com/specterops/dawgs/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgreSQLFetchStartNodesUsesBuilderCompilationCache(t *testing.T) {
+	previous := pg.SetOptimizedTranslation(true)
+	t.Cleanup(func() {
+		pg.SetOptimizedTranslation(previous)
+	})
+
+	userKind := graph.StringKind("CacheUser")
+	groupKind := graph.StringKind("CacheGroup")
+	memberKind := graph.StringKind("CacheMember")
+	session := Open(t, Options{
+		RequireDriver:        pg.DriverName,
+		SkipIfNoConnection:   true,
+		SkipIfDriverMismatch: true,
+		CleanupMode:          CleanupGraph,
+		ExtraNodeKinds:       graph.Kinds{userKind, groupKind},
+		ExtraEdgeKinds:       graph.Kinds{memberKind},
+	})
+	driver, ok := session.DB.(*pg.Driver)
+	require.True(t, ok)
+
+	var (
+		first  *graph.Node
+		second *graph.Node
+	)
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		var err error
+		if first, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "first"}), userKind); err != nil {
+			return err
+		}
+		if second, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "second"}), userKind); err != nil {
+			return err
+		}
+		target, err := tx.CreateNode(graph.AsProperties(map[string]any{"name": "target"}), groupKind)
+		if err != nil {
+			return err
+		}
+		if _, err = tx.CreateRelationshipByIDs(first.ID, target.ID, memberKind, graph.NewProperties()); err != nil {
+			return err
+		}
+		_, err = tx.CreateRelationshipByIDs(second.ID, target.ID, memberKind, graph.NewProperties())
+		return err
+	}))
+
+	before := driver.TranslationCacheStats()
+	require.NoError(t, session.DB.ReadTransaction(session.Ctx, func(tx graph.Transaction) error {
+		firstNodes, err := ops.FetchStartNodes(tx.Relationships().Filter(query.InIDs(query.Start(), first.ID)))
+		if err != nil {
+			return err
+		}
+		secondNodes, err := ops.FetchStartNodes(tx.Relationships().Filter(query.InIDs(query.Start(), second.ID)))
+		if err != nil {
+			return err
+		}
+		if _, found := firstNodes[first.ID]; !found {
+			t.Fatalf("first result omitted node %d", first.ID)
+		}
+		if _, found := secondNodes[second.ID]; !found {
+			t.Fatalf("second result omitted node %d", second.ID)
+		}
+		return nil
+	}))
+
+	after := driver.TranslationCacheStats()
+	require.Equal(t, before.Misses+1, after.Misses)
+	require.GreaterOrEqual(t, after.Hits, before.Hits+1)
+}
+
+func TestPostgreSQLFetchStartNodesUnoptimizedBypassesCache(t *testing.T) {
+	previous := pg.SetOptimizedTranslation(false)
+	t.Cleanup(func() {
+		pg.SetOptimizedTranslation(previous)
+	})
+
+	userKind := graph.StringKind("BaselineCacheUser")
+	groupKind := graph.StringKind("BaselineCacheGroup")
+	memberKind := graph.StringKind("BaselineCacheMember")
+	session := Open(t, Options{
+		RequireDriver:        pg.DriverName,
+		SkipIfNoConnection:   true,
+		SkipIfDriverMismatch: true,
+		CleanupMode:          CleanupGraph,
+		ExtraNodeKinds:       graph.Kinds{userKind, groupKind},
+		ExtraEdgeKinds:       graph.Kinds{memberKind},
+	})
+	driver, ok := session.DB.(*pg.Driver)
+	require.True(t, ok)
+
+	var (
+		first  *graph.Node
+		second *graph.Node
+	)
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		var err error
+		if first, err = tx.CreateNode(graph.NewProperties(), userKind); err != nil {
+			return err
+		}
+		if second, err = tx.CreateNode(graph.NewProperties(), userKind); err != nil {
+			return err
+		}
+		target, err := tx.CreateNode(graph.NewProperties(), groupKind)
+		if err != nil {
+			return err
+		}
+		if _, err = tx.CreateRelationshipByIDs(first.ID, target.ID, memberKind, graph.NewProperties()); err != nil {
+			return err
+		}
+		_, err = tx.CreateRelationshipByIDs(second.ID, target.ID, memberKind, graph.NewProperties())
+		return err
+	}))
+
+	before := driver.TranslationCacheStats()
+	require.NoError(t, session.DB.ReadTransaction(session.Ctx, func(tx graph.Transaction) error {
+		if _, err := ops.FetchStartNodes(tx.Relationships().Filter(query.InIDs(query.Start(), first.ID))); err != nil {
+			return err
+		}
+		_, err := ops.FetchStartNodes(tx.Relationships().Filter(query.InIDs(query.Start(), second.ID)))
+		return err
+	}))
+
+	after := driver.TranslationCacheStats()
+	require.Equal(t, before.Hits, after.Hits)
+	require.Equal(t, before.Misses, after.Misses)
+	require.Equal(t, before.Insertions, after.Insertions)
+	require.Equal(t, before.Bypasses+2, after.Bypasses)
+	require.Equal(t, before.UnoptimizedCompilations+2, after.UnoptimizedCompilations)
+}
+
+func TestPostgreSQLRawCypherQueryRebindsCachedParameters(t *testing.T) {
+	previous := pg.SetOptimizedTranslation(true)
+	t.Cleanup(func() {
+		pg.SetOptimizedTranslation(previous)
+	})
+
+	nodeKind := graph.StringKind("RawCypherCacheNode")
+	session := Open(t, Options{
+		RequireDriver:        pg.DriverName,
+		SkipIfNoConnection:   true,
+		SkipIfDriverMismatch: true,
+		CleanupMode:          CleanupGraph,
+		ExtraNodeKinds:       graph.Kinds{nodeKind},
+	})
+	driver, ok := session.DB.(*pg.Driver)
+	require.True(t, ok)
+
+	var (
+		first  *graph.Node
+		second *graph.Node
+	)
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		var err error
+		if first, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "first"}), nodeKind); err != nil {
+			return err
+		}
+		second, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "second"}), nodeKind)
+		return err
+	}))
+
+	before := driver.TranslationCacheStats()
+	require.NoError(t, session.DB.ReadTransaction(session.Ctx, func(tx graph.Transaction) error {
+		firstID, err := rawCypherNodeID(tx, "first")
+		if err != nil {
+			return err
+		}
+		secondID, err := rawCypherNodeID(tx, "second")
+		if err != nil {
+			return err
+		}
+		if firstID != first.ID || secondID != second.ID {
+			return fmt.Errorf("cached raw Cypher query returned incorrect node IDs: %d, %d", firstID, secondID)
+		}
+		return nil
+	}))
+
+	after := driver.TranslationCacheStats()
+	require.Equal(t, before.Misses+1, after.Misses)
+	require.GreaterOrEqual(t, after.Hits, before.Hits+1)
+}
+
+func TestPostgreSQLRawCypherQueryUnoptimizedBypassesCache(t *testing.T) {
+	previous := pg.SetOptimizedTranslation(false)
+	t.Cleanup(func() {
+		pg.SetOptimizedTranslation(previous)
+	})
+
+	nodeKind := graph.StringKind("RawCypherCacheBaselineNode")
+	session := Open(t, Options{
+		RequireDriver:        pg.DriverName,
+		SkipIfNoConnection:   true,
+		SkipIfDriverMismatch: true,
+		CleanupMode:          CleanupGraph,
+		ExtraNodeKinds:       graph.Kinds{nodeKind},
+	})
+	driver, ok := session.DB.(*pg.Driver)
+	require.True(t, ok)
+
+	before := driver.TranslationCacheStats()
+	require.NoError(t, session.DB.ReadTransaction(session.Ctx, func(tx graph.Transaction) error {
+		for _, name := range []string{"first", "second"} {
+			result := tx.Query("RETURN $name", map[string]any{"name": name})
+			if !result.Next() {
+				result.Close()
+				return result.Error()
+			}
+			result.Close()
+		}
+		return nil
+	}))
+
+	after := driver.TranslationCacheStats()
+	require.Equal(t, before.Hits, after.Hits)
+	require.Equal(t, before.Misses, after.Misses)
+	require.Equal(t, before.Bypasses+2, after.Bypasses)
+	require.Equal(t, before.UnoptimizedCompilations+2, after.UnoptimizedCompilations)
+}
+
+func rawCypherNodeID(tx graph.Transaction, name string) (graph.ID, error) {
+	result := tx.Query("MATCH (n:RawCypherCacheNode) WHERE n.name = $name RETURN n", map[string]any{"name": name})
+	defer result.Close()
+	if !result.Next() {
+		return 0, result.Error()
+	}
+
+	var node graph.Node
+	if err := result.Scan(&node); err != nil {
+		return 0, err
+	}
+	return node.ID, result.Error()
+}
+
+func TestPostgreSQLNodeUpdateRebindsCachedBuilderParameters(t *testing.T) {
+	previous := pg.SetOptimizedTranslation(true)
+	t.Cleanup(func() {
+		pg.SetOptimizedTranslation(previous)
+	})
+
+	nodeKind := graph.StringKind("CacheUpdateNode")
+	session := Open(t, Options{
+		RequireDriver:        pg.DriverName,
+		SkipIfNoConnection:   true,
+		SkipIfDriverMismatch: true,
+		CleanupMode:          CleanupGraph,
+		ExtraNodeKinds:       graph.Kinds{nodeKind},
+	})
+	driver, ok := session.DB.(*pg.Driver)
+	require.True(t, ok)
+
+	var (
+		first  *graph.Node
+		second *graph.Node
+	)
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		var err error
+		if first, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "before-first"}), nodeKind); err != nil {
+			return err
+		}
+		second, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "before-second"}), nodeKind)
+		return err
+	}))
+
+	before := driver.TranslationCacheStats()
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		firstProperties := graph.NewProperties().Set("name", "after-first")
+		if err := tx.Nodes().Filter(query.InIDs(query.Node(), first.ID)).Update(firstProperties); err != nil {
+			return err
+		}
+
+		secondProperties := graph.NewProperties().Set("name", "after-second")
+		return tx.Nodes().Filter(query.InIDs(query.Node(), second.ID)).Update(secondProperties)
+	}))
+	after := driver.TranslationCacheStats()
+	require.Equal(t, before.Misses+1, after.Misses)
+	require.GreaterOrEqual(t, after.Hits, before.Hits+1)
+
+	require.NoError(t, session.DB.ReadTransaction(session.Ctx, func(tx graph.Transaction) error {
+		updatedFirst, err := tx.Nodes().Filter(query.InIDs(query.Node(), first.ID)).First()
+		if err != nil {
+			return err
+		}
+		updatedSecond, err := tx.Nodes().Filter(query.InIDs(query.Node(), second.ID)).First()
+		if err != nil {
+			return err
+		}
+		firstName, err := updatedFirst.Properties.Get("name").String()
+		if err != nil {
+			return err
+		}
+		secondName, err := updatedSecond.Properties.Get("name").String()
+		if err != nil {
+			return err
+		}
+		if firstName != "after-first" || secondName != "after-second" {
+			return fmt.Errorf("cached update bound wrong values: got %q and %q", firstName, secondName)
+		}
+		return nil
+	}))
+}
+
+func TestPostgreSQLRelationshipUpdateRebindsCachedBuilderParameters(t *testing.T) {
+	previous := pg.SetOptimizedTranslation(true)
+	t.Cleanup(func() {
+		pg.SetOptimizedTranslation(previous)
+	})
+
+	nodeKind := graph.StringKind("CacheUpdateRelationshipNode")
+	relationshipKind := graph.StringKind("CacheUpdateRelationship")
+	session := Open(t, Options{
+		RequireDriver:        pg.DriverName,
+		SkipIfNoConnection:   true,
+		SkipIfDriverMismatch: true,
+		CleanupMode:          CleanupGraph,
+		ExtraNodeKinds:       graph.Kinds{nodeKind},
+		ExtraEdgeKinds:       graph.Kinds{relationshipKind},
+	})
+	driver, ok := session.DB.(*pg.Driver)
+	require.True(t, ok)
+
+	var (
+		first  *graph.Relationship
+		second *graph.Relationship
+	)
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		start, err := tx.CreateNode(graph.NewProperties(), nodeKind)
+		if err != nil {
+			return err
+		}
+		end, err := tx.CreateNode(graph.NewProperties(), nodeKind)
+		if err != nil {
+			return err
+		}
+		secondEnd, err := tx.CreateNode(graph.NewProperties(), nodeKind)
+		if err != nil {
+			return err
+		}
+		if first, err = tx.CreateRelationshipByIDs(start.ID, end.ID, relationshipKind, graph.AsProperties(map[string]any{"name": "before-first"})); err != nil {
+			return err
+		}
+		second, err = tx.CreateRelationshipByIDs(start.ID, secondEnd.ID, relationshipKind, graph.AsProperties(map[string]any{"name": "before-second"}))
+		return err
+	}))
+
+	before := driver.TranslationCacheStats()
+	require.NoError(t, session.DB.WriteTransaction(session.Ctx, func(tx graph.Transaction) error {
+		if err := tx.Relationships().Filter(query.InIDs(query.Relationship(), first.ID)).Update(graph.NewProperties().Set("name", "after-first")); err != nil {
+			return err
+		}
+		return tx.Relationships().Filter(query.InIDs(query.Relationship(), second.ID)).Update(graph.NewProperties().Set("name", "after-second"))
+	}))
+	after := driver.TranslationCacheStats()
+	require.Equal(t, before.Misses+1, after.Misses)
+	require.GreaterOrEqual(t, after.Hits, before.Hits+1)
+
+	require.NoError(t, session.DB.ReadTransaction(session.Ctx, func(tx graph.Transaction) error {
+		updatedFirst, err := tx.Relationships().Filter(query.InIDs(query.Relationship(), first.ID)).First()
+		if err != nil {
+			return err
+		}
+		updatedSecond, err := tx.Relationships().Filter(query.InIDs(query.Relationship(), second.ID)).First()
+		if err != nil {
+			return err
+		}
+		firstName, err := updatedFirst.Properties.Get("name").String()
+		if err != nil {
+			return err
+		}
+		secondName, err := updatedSecond.Properties.Get("name").String()
+		if err != nil {
+			return err
+		}
+		if firstName != "after-first" || secondName != "after-second" {
+			return fmt.Errorf("cached relationship update bound wrong values: got %q and %q", firstName, secondName)
+		}
+		return nil
+	}))
+}

--- a/query/rewrite.go
+++ b/query/rewrite.go
@@ -3,9 +3,8 @@ package query
 import (
 	"strconv"
 
-	"github.com/specterops/dawgs/cypher/models/walk"
-
 	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/walk"
 )
 
 type ParameterRewriter struct {
@@ -13,6 +12,19 @@ type ParameterRewriter struct {
 
 	Parameters     map[string]any
 	parameterIndex int
+	prefix         string
+}
+
+// ParameterNamer deterministically assigns names to parameters without
+// mutating the Cypher tree. It is useful to adapters that need a stable query
+// identity before deciding whether an owned copy is necessary.
+type ParameterNamer struct {
+	walk.Visitor[cypher.SyntaxNode]
+
+	Parameters     map[string]any
+	Symbols        []string
+	parameterIndex int
+	prefix         string
 }
 
 func NewParameterRewriter() *ParameterRewriter {
@@ -20,6 +32,28 @@ func NewParameterRewriter() *ParameterRewriter {
 		Visitor:        walk.NewVisitor[cypher.SyntaxNode](),
 		Parameters:     map[string]any{},
 		parameterIndex: 0,
+		prefix:         "p",
+	}
+}
+
+// NewParameterRewriterWithPrefix returns a rewriter whose generated names are
+// scoped to prefix. Adapters use this to distinguish builder-owned values from
+// caller supplied Cypher parameters.
+func NewParameterRewriterWithPrefix(prefix string) *ParameterRewriter {
+	rewriter := NewParameterRewriter()
+	rewriter.prefix = prefix
+	return rewriter
+}
+
+// NewParameterNamerWithPrefix returns a read-only parameter namer whose
+// generated names are scoped to prefix.
+func NewParameterNamerWithPrefix(prefix string) *ParameterNamer {
+	return &ParameterNamer{
+		Visitor:        walk.NewVisitor[cypher.SyntaxNode](),
+		Parameters:     map[string]any{},
+		Symbols:        []string{},
+		parameterIndex: 0,
+		prefix:         prefix,
 	}
 }
 
@@ -28,7 +62,7 @@ func (s *ParameterRewriter) Enter(node cypher.SyntaxNode) {
 	case *cypher.Parameter:
 		var (
 			nextParameterIndex    = s.parameterIndex
-			nextParameterIndexStr = "p" + strconv.Itoa(nextParameterIndex)
+			nextParameterIndexStr = s.prefix + strconv.Itoa(nextParameterIndex)
 		)
 
 		// Increment the parameter index first
@@ -37,5 +71,15 @@ func (s *ParameterRewriter) Enter(node cypher.SyntaxNode) {
 		// Record the parameter in our map and then bind the symbol in the model
 		s.Parameters[nextParameterIndexStr] = typedNode.Value
 		typedNode.Symbol = nextParameterIndexStr
+	}
+}
+
+func (s *ParameterNamer) Enter(node cypher.SyntaxNode) {
+	switch typedNode := node.(type) {
+	case *cypher.Parameter:
+		name := s.prefix + strconv.Itoa(s.parameterIndex)
+		s.parameterIndex++
+		s.Parameters[name] = typedNode.Value
+		s.Symbols = append(s.Symbols, name)
 	}
 }

--- a/query/rewrite_fuzz_test.go
+++ b/query/rewrite_fuzz_test.go
@@ -1,0 +1,70 @@
+package query
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	cypherFormat "github.com/specterops/dawgs/cypher/models/cypher/format"
+	"github.com/specterops/dawgs/cypher/models/walk"
+)
+
+// FuzzParameterNamerAndRewriterAgree protects the positional provenance used
+// by PostgreSQL builder-query caching. The non-mutating naming pass and the
+// rewriting pass must assign identical symbols and values in structural order.
+func FuzzParameterNamerAndRewriterAgree(f *testing.F) {
+	f.Add(int64(101), int64(202), int64(303))
+	f.Add(int64(-1), int64(0), int64(1))
+
+	f.Fuzz(func(t *testing.T, first, second, third int64) {
+		builder := NewBuilder(nil)
+		builder.Apply(
+			Where(And(
+				Equals(NodeProperty("first"), first),
+				Or(
+					GreaterThan(NodeProperty("second"), second),
+					LessThan(NodeProperty("third"), third),
+				),
+			)),
+			Returning(Node()),
+		)
+		regularQuery, err := builder.Build(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		namer := NewParameterNamerWithPrefix("fuzz_p")
+		if err := walk.Cypher(regularQuery, namer); err != nil {
+			t.Fatal(err)
+		}
+		namedSource, err := cypherFormat.RegularQueryWithParameterSequence(regularQuery, false, namer.Symbols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		owned := cypher.Copy(regularQuery)
+		rewriter := NewParameterRewriterWithPrefix("fuzz_p")
+		if err := walk.Cypher(owned, rewriter); err != nil {
+			t.Fatal(err)
+		}
+		rewrittenSource, err := cypherFormat.RegularQuery(owned, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if namedSource != rewrittenSource {
+			t.Fatalf("parameter naming diverged:\nnamed: %s\nrewritten: %s", namedSource, rewrittenSource)
+		}
+		if !reflect.DeepEqual(namer.Parameters, rewriter.Parameters) {
+			t.Fatalf("parameter values diverged: named=%v rewritten=%v", namer.Parameters, rewriter.Parameters)
+		}
+
+		originalSource, err := cypherFormat.RegularQuery(regularQuery, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if originalSource == rewrittenSource {
+			t.Fatal("parameter rewrite unexpectedly mutated the builder-owned query")
+		}
+	})
+}


### PR DESCRIPTION
## Description

Adds a bounded, driver-wide PostgreSQL Cypher-to-SQL translation cache. Cache hits avoid parsing, optimization, translation, and SQL formatting while rebuilding PostgreSQL bindings from the current caller parameter values.

The cache uses:
- generated-parameter provenance
- type and schema aware keys
- SIEVE eviction
- cacheable-miss coalescing
- lifecycle retirement
- aggregate query-text-free statistics

Successful schema assertions and kind refreshes invalidate prior cache generations. Documentation, unit tests, race coverage, and allocation benchmarks are included.

The goal of this effort is to reduce CPU burden by reducing allocations and caching intermediates of queries during translation and optimization. This is to steady a trend of greater CPU usage in BHE and BHCE.

Resolves: BED-9469

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [x] Test coverage
- [ ] Build / CI / tooling
- [x] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

Validated with:

- `make test`
- `go test ./drivers/pg ./cypher/models/pgsql/translate`
- `go test -race ./drivers/pg -run 'TranslationCache'`
- `go vet ./drivers/pg ./cypher/models/pgsql/translate`
- `git diff --check`
- Translation-cache benchmarks with `-benchmem`
- CRAP analysis from the full unit coverage profile

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a bounded PostgreSQL Cypher translation cache with configurable capacity, statistics, concurrent request handling, and parameter rebinding.
  - Added controls to enable or disable optimized translation and configure optimizer behavior.
  - Added stable parameter formatting, source mapping, and improved compilation for prepared and builder-based queries.
  - Added cache configuration and optimization controls for PostgreSQL drivers.

- **Bug Fixes**
  - Corrected relationship property updates to target relationships.
  - Improved schema-refresh and cache invalidation behavior.

- **Documentation**
  - Expanded PostgreSQL translation-cache documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->