### PR TITLE
feat: Add indexable case-insensitive string predicates - BED-9103

### DIFF
--- a/cypher/Cypher Syntax Support.md
+++ b/cypher/Cypher Syntax Support.md
@@ -457,6 +457,10 @@ regression coverage is limited to literal `CONTAINS`, `STARTS WITH`, and `ENDS W
 `LIKE` over `properties ->> key`. Dynamic parameter/property forms that lower to helper functions remain outside the
 index-match contract until their lowering changes.
 
+Programmatic callers can opt into `query.IndexableCaseInsensitiveStringContains` and
+`query.IndexableCaseInsensitiveStringStartsWith` for PostgreSQL-backed application search. These helpers are not raw
+Cypher syntax and lower to escaped raw-property `ILIKE` predicates that can use a matching `TextSearchIndex`.
+
 ### null Behavior
 
 Behavior around `null` in SQL differs from how Neo4j executes Cypher. Certain expression operators in Neo4j's

--- a/cypher/models/cypher/copy.go
+++ b/cypher/models/cypher/copy.go
@@ -83,6 +83,9 @@ func Copy[T any](value T, extensions ...CopyExtension[T]) T {
 	case *Comparison:
 		return any(typedValue.copy()).(T)
 
+	case *IndexableCaseInsensitiveStringPredicate:
+		return any(typedValue.copy()).(T)
+
 	case *ArithmeticExpression:
 		return any(typedValue.copy()).(T)
 

--- a/cypher/models/cypher/copy_test.go
+++ b/cypher/models/cypher/copy_test.go
@@ -73,6 +73,11 @@ func TestCopy(t *testing.T) {
 	})
 	validateCopy(t, &model2.Parenthetical{})
 	validateCopy(t, &model2.Comparison{})
+	validateCopy(t, model2.NewIndexableCaseInsensitiveStringPredicate(
+		model2.NewPropertyLookup("n", "name"),
+		model2.OperatorContains,
+		&model2.Parameter{Value: "needle"},
+	))
 	validateCopy(t, &model2.PartialComparison{
 		Operator: model2.OperatorAdd,
 	})
@@ -167,6 +172,21 @@ func TestCopy(t *testing.T) {
 	// External types
 	validateCopy(t, []string{})
 	validateCopy(t, graph.Kinds{})
+}
+
+func TestCopyIndexableCaseInsensitiveStringPredicateIsIndependent(t *testing.T) {
+	original := model2.NewIndexableCaseInsensitiveStringPredicate(
+		model2.NewPropertyLookup("n", "name"),
+		model2.OperatorContains,
+		&model2.Parameter{Value: "needle"},
+	)
+	copied := model2.Copy(original)
+
+	copied.Reference.(*model2.PropertyLookup).Atom.(*model2.Variable).Symbol = "copied"
+	copied.Value.Value = "copied needle"
+
+	require.Equal(t, "n", original.Reference.(*model2.PropertyLookup).Atom.(*model2.Variable).Symbol)
+	require.Equal(t, "needle", original.Value.Value)
 }
 
 func TestCopyPatternVariablesAreIndependent(t *testing.T) {

--- a/cypher/models/cypher/format/format.go
+++ b/cypher/models/cypher/format/format.go
@@ -584,6 +584,31 @@ func (s Emitter) WriteExpression(output io.Writer, expression cypher.Expression)
 			}
 		}
 
+	case *cypher.IndexableCaseInsensitiveStringPredicate:
+		if _, err := io.WriteString(output, "toLower("); err != nil {
+			return err
+		}
+
+		if err := s.WriteExpression(output, typedExpression.Reference); err != nil {
+			return err
+		}
+
+		if _, err := io.WriteString(output, ") "+typedExpression.Operator.String()+" "); err != nil {
+			return err
+		}
+
+		if _, err := io.WriteString(output, "toLower("); err != nil {
+			return err
+		}
+
+		if err := s.WriteExpression(output, typedExpression.Value); err != nil {
+			return err
+		}
+
+		if _, err := io.WriteString(output, ")"); err != nil {
+			return err
+		}
+
 	case *cypher.PartialComparison:
 		if _, err := io.WriteString(output, " "); err != nil {
 			return err

--- a/cypher/models/cypher/model.go
+++ b/cypher/models/cypher/model.go
@@ -1231,6 +1231,34 @@ func (s *Comparison) LastPartial() *PartialComparison {
 	return nil
 }
 
+// IndexableCaseInsensitiveStringPredicate represents a programmatic case-insensitive
+// string predicate that drivers may lower to an index-friendly expression.
+type IndexableCaseInsensitiveStringPredicate struct {
+	Reference Expression
+	Operator  Operator
+	Value     *Parameter
+}
+
+func NewIndexableCaseInsensitiveStringPredicate(reference Expression, operator Operator, value *Parameter) *IndexableCaseInsensitiveStringPredicate {
+	return &IndexableCaseInsensitiveStringPredicate{
+		Reference: reference,
+		Operator:  operator,
+		Value:     value,
+	}
+}
+
+func (s *IndexableCaseInsensitiveStringPredicate) copy() *IndexableCaseInsensitiveStringPredicate {
+	if s == nil {
+		return nil
+	}
+
+	return &IndexableCaseInsensitiveStringPredicate{
+		Reference: Copy(s.Reference),
+		Operator:  s.Operator,
+		Value:     Copy(s.Value),
+	}
+}
+
 type PartialComparison struct {
 	Operator Operator
 	Right    Expression

--- a/cypher/models/pgsql/translate/expression.go
+++ b/cypher/models/pgsql/translate/expression.go
@@ -1063,6 +1063,42 @@ func cypherStringPredicateFunction(function pgsql.Identifier, lOperand, rOperand
 	}, nil
 }
 
+func escapedLikePattern(value pgsql.Expression, prefix, suffix bool) (pgsql.Expression, error) {
+	escapedValue, err := cypherStringPredicateTextOperand(value)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, replacement := range []struct {
+		old string
+		new string
+	}{
+		{old: "\\", new: "\\\\"},
+		{old: "%", new: "\\%"},
+		{old: "_", new: "\\_"},
+	} {
+		escapedValue = pgsql.FunctionCall{
+			Function: pgsql.FunctionReplace,
+			Parameters: []pgsql.Expression{
+				escapedValue,
+				pgsql.NewLiteral(replacement.old, pgsql.Text),
+				pgsql.NewLiteral(replacement.new, pgsql.Text),
+			},
+			CastType: pgsql.Text,
+		}
+	}
+
+	var pattern pgsql.Expression = escapedValue
+	if prefix {
+		pattern = pgsql.NewBinaryExpression(pgsql.NewLiteral("%", pgsql.Text), pgsql.OperatorConcatenate, pattern)
+	}
+	if suffix {
+		pattern = pgsql.NewBinaryExpression(pattern, pgsql.OperatorConcatenate, pgsql.NewLiteral("%", pgsql.Text))
+	}
+
+	return pattern, nil
+}
+
 func (s *ExpressionTreeTranslator) rewriteBinaryExpression(newExpression *pgsql.BinaryExpression) error {
 	switch newExpression.Operator {
 	case pgsql.OperatorAdd:

--- a/cypher/models/pgsql/translate/translator.go
+++ b/cypher/models/pgsql/translate/translator.go
@@ -150,7 +150,7 @@ func (s *Translator) SetOptimizationPlan(plan optimize.Plan) {
 func (s *Translator) Enter(expression cypher.SyntaxNode) {
 	switch typedExpression := expression.(type) {
 	case *cypher.RegularQuery, *cypher.SingleQuery, *cypher.PatternElement,
-		*cypher.Comparison, *cypher.Skip, *cypher.Limit, cypher.Operator, *cypher.ArithmeticExpression,
+		*cypher.Comparison, *cypher.IndexableCaseInsensitiveStringPredicate, *cypher.Skip, *cypher.Limit, cypher.Operator, *cypher.ArithmeticExpression,
 		*cypher.NodePattern, *cypher.RelationshipPattern, *cypher.Remove, *cypher.Set,
 		*cypher.ReadingClause, *cypher.UnaryAddOrSubtractExpression, *cypher.PropertyLookup,
 		*cypher.Negation, *cypher.Where, *cypher.ListLiteral,
@@ -532,6 +532,39 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 
 	case *cypher.FunctionInvocation:
 		s.translateFunction(typedExpression)
+
+	case *cypher.IndexableCaseInsensitiveStringPredicate:
+		if value, err := s.treeTranslator.PopOperand(); err != nil {
+			s.SetError(err)
+		} else if reference, err := s.treeTranslator.PopOperand(); err != nil {
+			s.SetError(err)
+		} else if textReference, err := cypherStringPredicateTextOperand(reference); err != nil {
+			s.SetError(err)
+		} else {
+			var (
+				prefix bool
+				suffix bool
+			)
+
+			switch typedExpression.Operator {
+			case cypher.OperatorContains:
+				prefix = true
+				suffix = true
+
+			case cypher.OperatorStartsWith:
+				suffix = true
+
+			default:
+				s.SetErrorf("unsupported indexable case-insensitive string predicate operator: %s", typedExpression.Operator)
+				return
+			}
+
+			if pattern, err := escapedLikePattern(value, prefix, suffix); err != nil {
+				s.SetError(err)
+			} else {
+				s.treeTranslator.PushOperand(pgsql.NewBinaryExpression(textReference, pgsql.OperatorILike, pattern))
+			}
+		}
 
 	case *cypher.UnaryAddOrSubtractExpression:
 		if operand, err := s.treeTranslator.PopOperand(); err != nil {

--- a/cypher/models/walk/walk_cypher.go
+++ b/cypher/models/walk/walk_cypher.go
@@ -400,6 +400,16 @@ func newCypherOperatorWalkCursor(node cypher.SyntaxNode) (*Cursor[cypher.SyntaxN
 	case *cypher.Comparison:
 		return newCypherWalkCursorWithBranchPrefix(node, typedNode.Left, typedNode.Partials), true
 
+	case *cypher.IndexableCaseInsensitiveStringPredicate:
+		nextCursor := &Cursor[cypher.SyntaxNode]{Node: node}
+		if typedNode.Reference != nil {
+			nextCursor.AddBranches(typedNode.Reference)
+		}
+		if typedNode.Value != nil {
+			nextCursor.AddBranches(typedNode.Value)
+		}
+		return nextCursor, true
+
 	case *cypher.UnaryAddOrSubtractExpression:
 		nextCursor := &Cursor[cypher.SyntaxNode]{Node: node}
 		if typedNode.Right != nil {

--- a/cypher/models/walk/walk_test.go
+++ b/cypher/models/walk/walk_test.go
@@ -912,6 +912,14 @@ func TestCypherWalkSemanticTraversalSequences(t *testing.T) {
 			},
 			expected: []string{"variable:left", "variable:right"},
 		},
+		"indexable case-insensitive predicate walks reference then value": {
+			node: cypher.NewIndexableCaseInsensitiveStringPredicate(
+				cypher.NewPropertyLookup("node", "name"),
+				cypher.OperatorContains,
+				&cypher.Parameter{Symbol: "value"},
+			),
+			expected: []string{"variable:node", "parameter:value"},
+		},
 		"arithmetic walks left operator then right": {
 			node: &cypher.ArithmeticExpression{
 				Left: cypher.NewVariableWithSymbol("left"),

--- a/docs/postgresql_translation.md
+++ b/docs/postgresql_translation.md
@@ -59,6 +59,12 @@ Substring and suffix predicates are not promoted to blanket schema indexes. Post
 parameter/property forms that lower to helper functions remain outside the hard index-match contract until their
 lowering changes.
 
+The programmatic `query.IndexableCaseInsensitiveStringContains` and
+`query.IndexableCaseInsensitiveStringStartsWith` helpers are an explicit exception for PostgreSQL-backed application
+search. They lower to escaped raw-property `ILIKE` predicates and can use a matching `TextSearchIndex`. They are not
+raw Cypher syntax: formatting and reparsing them as ordinary `toLower(...) CONTAINS` or `STARTS WITH` Cypher uses the
+normal dynamic helper-function lowering instead.
+
 ## Validation Workflow
 
 Optimizer changes should include focused optimizer/lowering tests, SQL-shape translation tests, and backend-equivalent

--- a/integration/pgsql_property_equality_test.go
+++ b/integration/pgsql_property_equality_test.go
@@ -52,6 +52,116 @@ func assertRelationshipIDs(t *testing.T, actual []graph.ID, expected ...graph.ID
 	}
 }
 
+func assertFetchedNodeIDs(t *testing.T, actual []graph.ID, expected ...graph.ID) {
+	t.Helper()
+
+	if len(actual) != len(expected) {
+		t.Fatalf("node IDs: got %v, want %v", actual, expected)
+	}
+
+	remaining := make(map[graph.ID]int, len(expected))
+	for _, id := range expected {
+		remaining[id]++
+	}
+
+	for _, id := range actual {
+		if remaining[id] == 0 {
+			t.Fatalf("node IDs: got %v, want %v", actual, expected)
+		}
+		remaining[id]--
+	}
+}
+
+func TestPostgreSQLIndexableCaseInsensitiveStringPredicates(t *testing.T) {
+	connStr := os.Getenv("CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("CONNECTION_STRING env var is not set")
+	}
+
+	driver, err := DriverFromConnectionString(connStr)
+	if err != nil {
+		t.Fatalf("failed to detect driver: %v", err)
+	}
+	if driver != pg.DriverName {
+		t.Skipf("CONNECTION_STRING is not a PostgreSQL connection string")
+	}
+
+	var (
+		userKind = graph.StringKind("User")
+		db, ctx  = SetupDBWithKinds(t, CleanupGraph, graph.Kinds{userKind}, nil)
+		matching *graph.Node
+		prefix   *graph.Node
+		other    *graph.Node
+		missing  *graph.Node
+	)
+
+	if err := db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+		var err error
+		if matching, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "Prefix-NeEdLe%_\\-Suffix"}), userKind); err != nil {
+			return err
+		}
+		if prefix, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "PrEfIx-Other"}), userKind); err != nil {
+			return err
+		}
+		if other, err = tx.CreateNode(graph.AsProperties(map[string]any{"name": "Other Value"}), userKind); err != nil {
+			return err
+		}
+		if missing, err = tx.CreateNode(graph.NewProperties(), userKind); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to create fixture: %v", err)
+	}
+
+	testCases := []struct {
+		name     string
+		criteria graph.Criteria
+		expected []graph.ID
+	}{
+		{
+			name:     "contains is case insensitive and treats LIKE wildcards literally",
+			criteria: query.IndexableCaseInsensitiveStringContains(query.NodeProperty("name"), `nEeDlE%_\`),
+			expected: []graph.ID{matching.ID},
+		},
+		{
+			name:     "starts with is case insensitive",
+			criteria: query.IndexableCaseInsensitiveStringStartsWith(query.NodeProperty("name"), "pReFiX-"),
+			expected: []graph.ID{matching.ID, prefix.ID},
+		},
+		{
+			name:     "negated contains includes missing properties",
+			criteria: query.Not(query.IndexableCaseInsensitiveStringContains(query.NodeProperty("name"), `nEeDlE%_\`)),
+			expected: []graph.ID{prefix.ID, other.ID, missing.ID},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var actual []graph.ID
+
+			err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+				return tx.Nodes().Filter(query.And(
+					query.Kind(query.Node(), userKind),
+					testCase.criteria,
+				)).FetchIDs(func(cursor graph.Cursor[graph.ID]) error {
+					for id := range cursor.Chan() {
+						actual = append(actual, id)
+					}
+
+					return cursor.Error()
+				})
+			})
+			if err != nil {
+				t.Fatalf("query failed: %v", err)
+			}
+
+			assertFetchedNodeIDs(t, actual, testCase.expected...)
+		})
+	}
+}
+
 func TestPostgreSQLPropertyTextEqualityCompatibility(t *testing.T) {
 	connStr := os.Getenv("CONNECTION_STRING")
 	if connStr == "" {

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -102,6 +102,62 @@ func TestBuilderRendersRawPropertyKeys(t *testing.T) {
 	}
 }
 
+func TestIndexableCaseInsensitiveStringPredicatesTranslateToILike(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		property string
+		criteria graph.Criteria
+	}{
+		{
+			name:     "contains",
+			property: "name",
+			criteria: query.IndexableCaseInsensitiveStringContains(query.NodeProperty("name"), `Needle%_\\`),
+		},
+		{
+			name:     "starts with",
+			property: "objectid",
+			criteria: query.IndexableCaseInsensitiveStringStartsWith(query.NodeProperty("objectid"), `Needle%_\\`),
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			builder := query.NewBuilder(nil)
+			builder.Apply(query.Where(testCase.criteria), query.Returning(query.Node()))
+
+			regularQuery, err := builder.Build(false)
+			if err != nil {
+				t.Fatalf("build query: %v", err)
+			}
+
+			translated, err := translate.FromCypher(context.Background(), regularQuery, nil, false, 1)
+			if err != nil {
+				t.Fatalf("translate PostgreSQL query: %v", err)
+			}
+
+			sql := strings.ToLower(translated.Statement)
+			for _, expected := range []string{
+				" ilike ",
+				"replace(",
+				"->> '" + testCase.property + "'",
+			} {
+				if !strings.Contains(sql, expected) {
+					t.Errorf("PostgreSQL query missing %q:\n%s", expected, translated.Statement)
+				}
+			}
+
+			for _, unexpected := range []string{
+				"lower((n0.properties",
+				"cypher_contains(",
+				"cypher_starts_with(",
+				"__dawgs_",
+			} {
+				if strings.Contains(sql, unexpected) {
+					t.Errorf("PostgreSQL query unexpectedly contains %q:\n%s", unexpected, translated.Statement)
+				}
+			}
+		})
+	}
+}
+
 func assertRetrieverProjection(t *testing.T, rendered string) {
 	t.Helper()
 

--- a/query/model.go
+++ b/query/model.go
@@ -283,6 +283,24 @@ func CaseInsensitiveStringEndsWith(reference graph.Criteria, value string) *cyph
 	)
 }
 
+// IndexableCaseInsensitiveStringContains builds a case-insensitive contains predicate that PostgreSQL can render with a matching text-search index.
+func IndexableCaseInsensitiveStringContains(reference graph.Criteria, value string) *cypherModel.IndexableCaseInsensitiveStringPredicate {
+	return cypherModel.NewIndexableCaseInsensitiveStringPredicate(
+		reference,
+		cypherModel.OperatorContains,
+		Parameter(strings.ToLower(value)),
+	)
+}
+
+// IndexableCaseInsensitiveStringStartsWith builds a case-insensitive prefix predicate that PostgreSQL can render with a matching text-search index.
+func IndexableCaseInsensitiveStringStartsWith(reference graph.Criteria, value string) *cypherModel.IndexableCaseInsensitiveStringPredicate {
+	return cypherModel.NewIndexableCaseInsensitiveStringPredicate(
+		reference,
+		cypherModel.OperatorStartsWith,
+		Parameter(strings.ToLower(value)),
+	)
+}
+
 func Equals(reference graph.Criteria, value any) *cypherModel.Comparison {
 	return cypherModel.NewComparison(reference, cypherModel.OperatorEquals, Parameter(value))
 }

--- a/query/neo4j/neo4j_test.go
+++ b/query/neo4j/neo4j_test.go
@@ -716,6 +716,36 @@ func TestQueryBuilder_Render(t *testing.T) {
 		),
 	), "match (n) where toLower(n.tags) starts with $p0 return n"))
 
+	t.Run("Node String Item Indexable Case Insensitive Contains With Uppercase Parameter", assertQueryResult(query.SinglePartQuery(
+		query.Where(
+			cypher.NewIndexableCaseInsensitiveStringPredicate(query.NodeProperty("tags"), cypher.OperatorContains, query.Parameter("TAG_1")),
+		),
+
+		query.Returning(
+			query.Node(),
+		),
+	), "match (n) where toLower(n.tags) contains toLower($p0) return n"))
+
+	t.Run("Node String Item Indexable Case Insensitive Contains", assertQueryResult(query.SinglePartQuery(
+		query.Where(
+			query.IndexableCaseInsensitiveStringContains(query.NodeProperty("tags"), "tag_1"),
+		),
+
+		query.Returning(
+			query.Node(),
+		),
+	), "match (n) where toLower(n.tags) contains toLower($p0) return n"))
+
+	t.Run("Node String Item Indexable Case Insensitive Starts With", assertQueryResult(query.SinglePartQuery(
+		query.Where(
+			query.IndexableCaseInsensitiveStringStartsWith(query.NodeProperty("tags"), "tag_1"),
+		),
+
+		query.Returning(
+			query.Node(),
+		),
+	), "match (n) where toLower(n.tags) starts with toLower($p0) return n"))
+
 	t.Run("Node String Item Case Insensitive Ends With", assertQueryResult(query.SinglePartQuery(
 		query.Where(
 			query.CaseInsensitiveStringEndsWith(query.NodeProperty("tags"), "tag_1"),
@@ -1071,6 +1101,30 @@ func TestQueryBuilder_Render(t *testing.T) {
 			query.Count(query.Node()),
 		),
 	), "match (n) where (not (n.system_tags contains $p0) or n.system_tags is null) return count(n)"))
+
+	t.Run("Not Indexable Case Insensitive String Contains Operator Rewrite", assertQueryResult(query.SinglePartQuery(
+		query.Where(
+			query.Not(
+				query.IndexableCaseInsensitiveStringContains(query.Property(query.Node(), SystemTags), "admin_tier_0"),
+			),
+		),
+
+		query.Returning(
+			query.Count(query.Node()),
+		),
+	), "match (n) where (not (toLower(n.system_tags) contains toLower($p0)) or n.system_tags is null) return count(n)"))
+
+	t.Run("Not Indexable Case Insensitive String Starts With Operator Rewrite", assertQueryResult(query.SinglePartQuery(
+		query.Where(
+			query.Not(
+				query.IndexableCaseInsensitiveStringStartsWith(query.Property(query.Node(), SystemTags), "admin"),
+			),
+		),
+
+		query.Returning(
+			query.Count(query.Node()),
+		),
+	), "match (n) where (not (toLower(n.system_tags) starts with toLower($p0)) or n.system_tags is null) return count(n)"))
 
 	t.Run("Is Not Null", assertQueryResult(query.SinglePartQuery(
 		query.Where(

--- a/query/neo4j/rewrite.go
+++ b/query/neo4j/rewrite.go
@@ -73,23 +73,35 @@ func unwrapParenthetical(expression cypher.SyntaxNode) cypher.SyntaxNode {
 
 func (s *ExpressionListRewriter) rewriteStringNegation(negation *cypher.Negation) {
 	if ancestorExpressionList, isExpressionList := s.peekExpressionList(); isExpressionList {
+		var (
+			reference cypher.Expression
+			operator  cypher.Operator
+		)
+
 		switch typedNegatedExpression := unwrapParenthetical(negation.Expression).(type) {
 		case *cypher.Comparison:
 			firstPartial := typedNegatedExpression.FirstPartial()
-
-			// If the negated expression is a comparison check to see if it's a string comparison. This is done since
-			// Neo4j comparison semantics for strings regarding `null` has edge cases that must be accounted for
-			switch firstPartial.Operator {
-			case cypher.OperatorStartsWith, cypher.OperatorEndsWith, cypher.OperatorContains:
-				// Rewrite this comparison is a disjunction of the negation and a follow-on comparison to handle null
-				// checks
-				ancestorExpressionList.Replace(ancestorExpressionList.IndexOf(negation), &cypher.Parenthetical{
-					Expression: cypher.NewDisjunction(
-						negation,
-						cypher.NewComparison(typedNegatedExpression.Left, cypher.OperatorIs, query.Literal(nil)),
-					),
-				})
+			if firstPartial == nil {
+				return
 			}
+
+			reference = typedNegatedExpression.Left
+			operator = firstPartial.Operator
+
+		case *cypher.IndexableCaseInsensitiveStringPredicate:
+			reference = typedNegatedExpression.Reference
+			operator = typedNegatedExpression.Operator
+		}
+
+		// Neo4j comparison semantics for strings regarding `null` has edge cases that must be accounted for.
+		switch operator {
+		case cypher.OperatorStartsWith, cypher.OperatorEndsWith, cypher.OperatorContains:
+			ancestorExpressionList.Replace(ancestorExpressionList.IndexOf(negation), &cypher.Parenthetical{
+				Expression: cypher.NewDisjunction(
+					negation,
+					cypher.NewComparison(reference, cypher.OperatorIs, query.Literal(nil)),
+				),
+			})
 		}
 	}
 }


### PR DESCRIPTION
## Description

Adds first-class case-insensitive string predicates for application code that needs PostgreSQL-indexable fuzzy and prefix search.

Generic dynamic CySQL `CONTAINS` and `STARTS WITH` predicates lower through PostgreSQL helper functions, which preserve Cypher semantics but cannot use trigram expression indexes. The new opt-in predicates lower directly to escaped `ILIKE` expressions, allowing `TextSearchIndex`/GIN trigram indexes to be used.

Neo4j lowers the same predicates to equivalent `toLower(...)` expressions.

Generic CySQL behavior and existing string predicate behavior are unchanged. Consumers must opt into the new indexable predicates.

Resolves: BED-9103


## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [x] Test coverage
- [ ] Build / CI / tooling
- [x] Documentation


## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

Ran focused unit tests for Cypher AST copying/walking, PostgreSQL translation, query builders, and Neo4j rewriting.

Ran the manual PostgreSQL integration test covering case-insensitivity, literal `%`, `_`, and `\`, negation, and missing properties.

Verified PostgreSQL query plans use trigram indexes for the new predicates.

## Driver Impact

- [x] PostgreSQL driver (`drivers/pg`)
- [x] Neo4j driver (`drivers/neo4j`)


## Checklist

- [ ] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case-insensitive, index-aware string filters for “contains” and “starts with” searches.
  * PostgreSQL translations now use escaped `ILIKE` expressions compatible with text-search indexes.
  * Negated filters safely include records with missing properties.
* **Bug Fixes**
  * Improved handling of wildcard characters and null values in string filtering.
* **Documentation**
  * Documented the new filtering helpers and PostgreSQL indexing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->