### PR TITLE
feat: reduce redundant optimizer work - BED-9469

### DIFF
--- a/cypher/models/pgsql/optimize/direction.go
+++ b/cypher/models/pgsql/optimize/direction.go
@@ -25,10 +25,19 @@ func (s InboundTraversalReversalRule) Name() string {
 	return "InboundTraversalReversal"
 }
 
+func (s InboundTraversalReversalRule) usesLazyCopy() bool {
+	return true
+}
+
 func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
 	if plan == nil || plan.Query == nil || plan.Query.SingleQuery == nil {
 		return false, nil
 	}
+	if !queryWouldReverseInboundTraversal(plan.Query) {
+		return false, nil
+	}
+
+	plan.EnsureMutable()
 
 	singleQuery := plan.Query.SingleQuery
 
@@ -44,6 +53,72 @@ func (s InboundTraversalReversalRule) Apply(plan *Plan) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+func queryWouldReverseInboundTraversal(query *cypher.RegularQuery) bool {
+	if query == nil || query.SingleQuery == nil {
+		return false
+	}
+
+	singleQuery := query.SingleQuery
+	switch {
+	case singleQuery.SinglePartQuery != nil && singleQuery.MultiPartQuery != nil:
+		return false
+	case singleQuery.SinglePartQuery != nil:
+		return readingClausesWouldReverseInboundTraversal(singleQuery.SinglePartQuery.ReadingClauses, map[string]struct{}{})
+	case singleQuery.MultiPartQuery != nil:
+		return multiPartQueryWouldReverseInboundTraversal(singleQuery.MultiPartQuery)
+	default:
+		return false
+	}
+}
+
+func multiPartQueryWouldReverseInboundTraversal(query *cypher.MultiPartQuery) bool {
+	if query == nil || query.SinglePartQuery == nil {
+		return false
+	}
+
+	declaredSymbols := map[string]struct{}{}
+	for _, part := range query.Parts {
+		if part == nil {
+			continue
+		}
+
+		if readingClausesWouldReverseInboundTraversal(part.ReadingClauses, declaredSymbols) {
+			return true
+		}
+		if part.With != nil {
+			declaredSymbols, _ = carryProjectionSelectivity(part.With.Projection, declaredSymbols, map[string]boundSourceSelectivity{})
+		}
+	}
+
+	return readingClausesWouldReverseInboundTraversal(query.SinglePartQuery.ReadingClauses, declaredSymbols)
+}
+
+func readingClausesWouldReverseInboundTraversal(readingClauses []*cypher.ReadingClause, declaredSymbols map[string]struct{}) bool {
+	for _, readingClause := range readingClauses {
+		if readingClause == nil {
+			continue
+		}
+
+		if match := readingClause.Match; match != nil {
+			if !match.Optional {
+				searchSymbols := whereSearchPredicateSymbols(match)
+				for _, patternPart := range match.Pattern {
+					if inboundTraversalReversalCandidate(patternPart, declaredSymbols, searchSymbols) {
+						return true
+					}
+				}
+			}
+			declareMatchSymbols(declaredSymbols, match)
+		}
+
+		if unwind := readingClause.Unwind; unwind != nil {
+			addSymbol(declaredSymbols, variableSymbol(unwind.Variable))
+		}
+	}
+
+	return false
 }
 
 // reverseInboundTraversalMultiPartQuery processes each single-part segment of a multi-part query,

--- a/cypher/models/pgsql/optimize/lowering_plan.go
+++ b/cypher/models/pgsql/optimize/lowering_plan.go
@@ -109,14 +109,15 @@ func appendQueryPartLowerings(
 	if err != nil {
 		return err
 	}
+	indexedPatternPredicates := indexedPatternPredicatesInQueryPart(queryPart)
 
 	appendExactRangeExpansionDecisions(plan, queryPartIndex, readingClauses)
-	appendPatternPredicateExactRangeExpansionDecisions(plan, queryPartIndex, queryPart)
+	appendPatternPredicateExactRangeExpansionDecisions(plan, queryPartIndex, indexedPatternPredicates)
 	appendPathRelationshipPredicateDecisions(plan, queryPartIndex, queryPart)
 	appendProjectionPruningDecisions(plan, queryPartIndex, readingClauses, sourceReferences)
 	appendLatePathMaterializationDecisions(plan, queryPartIndex, readingClauses, sourceReferences)
-	appendPatternPredicateProjectionLowerings(plan, queryPartIndex, queryPart, sourceReferences)
-	appendPatternPredicatePlacementDecisions(plan, queryPartIndex, queryPart)
+	appendPatternPredicateProjectionLowerings(plan, queryPartIndex, indexedPatternPredicates, sourceReferences)
+	appendPatternPredicatePlacementDecisions(plan, queryPartIndex, indexedPatternPredicates)
 	appendExpandIntoDecisions(plan, queryPartIndex, readingClauses)
 	appendTraversalDirectionDecisions(plan, queryPartIndex, readingClauses, bindingPredicateSymbols(predicateAttachments, queryPartIndex), initialDeclaredSymbols, initialSelectivity)
 	shortestPathSearchSymbols := shortestPathSearchPredicateSymbols(readingClauses)
@@ -143,8 +144,8 @@ func appendExactRangeExpansionDecisions(plan *LoweringPlan, queryPartIndex int, 
 	}
 }
 
-func appendPatternPredicateExactRangeExpansionDecisions(plan *LoweringPlan, queryPartIndex int, queryPart cypher.SyntaxNode) {
-	for _, indexedPredicate := range indexedPatternPredicatesInQueryPart(queryPart) {
+func appendPatternPredicateExactRangeExpansionDecisions(plan *LoweringPlan, queryPartIndex int, indexedPredicates []indexedPatternPredicate) {
+	for _, indexedPredicate := range indexedPredicates {
 		patternPart := patternPartForPredicate(indexedPredicate.Predicate)
 		appendPatternExactRangeExpansionDecisions(plan, PatternTarget{
 			QueryPartIndex: queryPartIndex,
@@ -397,8 +398,8 @@ func appendPatternProjectionPruningDecisions(plan *LoweringPlan, target PatternT
 	}
 }
 
-func appendPatternPredicateProjectionLowerings(plan *LoweringPlan, queryPartIndex int, queryPart cypher.SyntaxNode, sourceReferences map[string]struct{}) {
-	for _, indexedPredicate := range indexedPatternPredicatesInQueryPart(queryPart) {
+func appendPatternPredicateProjectionLowerings(plan *LoweringPlan, queryPartIndex int, indexedPredicates []indexedPatternPredicate, sourceReferences map[string]struct{}) {
+	for _, indexedPredicate := range indexedPredicates {
 		var (
 			predicate   = indexedPredicate.Predicate
 			patternPart = patternPartForPredicate(predicate)
@@ -422,8 +423,8 @@ func appendPatternPredicateProjectionLowerings(plan *LoweringPlan, queryPartInde
 	}
 }
 
-func appendPatternPredicatePlacementDecisions(plan *LoweringPlan, queryPartIndex int, queryPart cypher.SyntaxNode) {
-	for _, indexedPredicate := range indexedPatternPredicatesInQueryPart(queryPart) {
+func appendPatternPredicatePlacementDecisions(plan *LoweringPlan, queryPartIndex int, indexedPredicates []indexedPatternPredicate) {
+	for _, indexedPredicate := range indexedPredicates {
 		var (
 			predicate   = indexedPredicate.Predicate
 			patternPart = patternPartForPredicate(predicate)
@@ -1060,6 +1061,11 @@ func propertyLookupVariableSymbol(expression cypher.Expression) (string, bool) {
 }
 
 func expressionReferencesAnySource(expression cypher.Expression) bool {
+	switch expression.(type) {
+	case nil, *cypher.Literal, *cypher.Parameter:
+		return false
+	}
+
 	references, err := collectReferencedSourceIdentifiers(expression)
 	return err != nil || len(references) > 0
 }

--- a/cypher/models/pgsql/optimize/optimizer.go
+++ b/cypher/models/pgsql/optimize/optimizer.go
@@ -11,6 +11,14 @@ type analysisPreservingRule interface {
 	preservesAnalysis() bool
 }
 
+// lazyCopyRule promises that Apply does not mutate the input query unless it
+// first calls Plan.EnsureMutable. Built-in rules use this to avoid copying a
+// query when no rewrite applies. Third-party rules retain the historical safe
+// behavior: the optimizer copies before invoking them.
+type lazyCopyRule interface {
+	usesLazyCopy() bool
+}
+
 type RuleResult struct {
 	Name    string `json:"name"`
 	Applied bool   `json:"applied"`
@@ -39,6 +47,18 @@ type Plan struct {
 	LoweringPlan         LoweringPlan
 	Rules                []RuleResult
 	PredicateAttachments []PredicateAttachment
+	queryCopied          bool
+}
+
+// EnsureMutable gives a rule an owned query before it changes the AST. It is
+// intentionally idempotent so multiple applied rules share one copy.
+func (s *Plan) EnsureMutable() *cypher.RegularQuery {
+	if s != nil && !s.queryCopied && s.Query != nil {
+		s.Query = cypher.Copy(s.Query)
+		s.queryCopied = true
+	}
+
+	return s.Query
 }
 
 type Optimizer struct {
@@ -63,17 +83,46 @@ func Optimize(query *cypher.RegularQuery) (Plan, error) {
 	return NewOptimizer(DefaultRules()...).Optimize(query)
 }
 
+// OptimizeBorrowed optimizes query without copying it up front. The returned
+// plan aliases query when no rewrite applies; rules must call EnsureMutable
+// before modifying the tree. It is intended for callers that already own the
+// input tree and can treat the returned plan as read-only.
+func OptimizeBorrowed(query *cypher.RegularQuery) (Plan, error) {
+	return NewOptimizer(DefaultRules()...).OptimizeBorrowed(query)
+}
+
+// Optimize preserves the historical ownership contract: the returned plan
+// always owns its query independently of the caller's input.
 func (s Optimizer) Optimize(query *cypher.RegularQuery) (Plan, error) {
 	if query == nil {
 		return Plan{}, nil
 	}
 
+	return s.optimize(cypher.Copy(query), true)
+}
+
+// OptimizeBorrowed applies the optimizer without copying query until a rule
+// needs to mutate it. See OptimizeBorrowed for ownership details.
+func (s Optimizer) OptimizeBorrowed(query *cypher.RegularQuery) (Plan, error) {
+	return s.optimize(query, false)
+}
+
+func (s Optimizer) optimize(query *cypher.RegularQuery, queryCopied bool) (Plan, error) {
+	if query == nil {
+		return Plan{}, nil
+	}
+
 	plan := Plan{
-		Query: cypher.Copy(query),
+		Query:       query,
+		queryCopied: queryCopied,
 	}
 	plan.Analysis = Analyze(plan.Query)
 
 	for _, rule := range s.rules {
+		if lazyRule, usesLazyCopy := rule.(lazyCopyRule); !usesLazyCopy || !lazyRule.usesLazyCopy() {
+			plan.EnsureMutable()
+		}
+
 		applied, err := rule.Apply(&plan)
 		if err != nil {
 			return Plan{}, err
@@ -110,6 +159,10 @@ func (s PredicateAttachmentRule) Name() string {
 }
 
 func (s PredicateAttachmentRule) preservesAnalysis() bool {
+	return true
+}
+
+func (s PredicateAttachmentRule) usesLazyCopy() bool {
 	return true
 }
 

--- a/cypher/models/pgsql/optimize/optimizer.go
+++ b/cypher/models/pgsql/optimize/optimizer.go
@@ -7,6 +7,10 @@ type Rule interface {
 	Apply(*Plan) (bool, error)
 }
 
+type analysisPreservingRule interface {
+	preservesAnalysis() bool
+}
+
 type RuleResult struct {
 	Name    string `json:"name"`
 	Applied bool   `json:"applied"`
@@ -79,7 +83,10 @@ func (s Optimizer) Optimize(query *cypher.RegularQuery) (Plan, error) {
 			Name:    rule.Name(),
 			Applied: applied,
 		})
-		plan.Analysis = Analyze(plan.Query)
+
+		if applied && !rulePreservesAnalysis(rule) {
+			plan.Analysis = Analyze(plan.Query)
+		}
 	}
 
 	if loweringPlan, err := BuildLoweringPlan(plan.Query, plan.PredicateAttachments); err != nil {
@@ -91,10 +98,19 @@ func (s Optimizer) Optimize(query *cypher.RegularQuery) (Plan, error) {
 	return plan, nil
 }
 
+func rulePreservesAnalysis(rule Rule) bool {
+	preservingRule, preserves := rule.(analysisPreservingRule)
+	return preserves && preservingRule.preservesAnalysis()
+}
+
 type PredicateAttachmentRule struct{}
 
 func (s PredicateAttachmentRule) Name() string {
 	return "PredicateAttachment"
+}
+
+func (s PredicateAttachmentRule) preservesAnalysis() bool {
+	return true
 }
 
 func (s PredicateAttachmentRule) Apply(plan *Plan) (bool, error) {

--- a/cypher/models/pgsql/optimize/optimizer_benchmark_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_benchmark_test.go
@@ -1,0 +1,34 @@
+package optimize
+
+import (
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/frontend"
+)
+
+const trivialOptimizerBenchmarkQuery = `MATCH (n) RETURN n`
+
+func BenchmarkOptimizeTrivialQuery(b *testing.B) {
+	benchmarkOptimizeQuery(b, trivialOptimizerBenchmarkQuery)
+}
+
+func BenchmarkOptimizeADCSQuery(b *testing.B) {
+	benchmarkOptimizeQuery(b, adcsQuery)
+}
+
+func benchmarkOptimizeQuery(b *testing.B, query string) {
+	b.Helper()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), query)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for idx := 0; idx < b.N; idx++ {
+		if _, err := Optimize(regularQuery); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cypher/models/pgsql/optimize/optimizer_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_test.go
@@ -23,6 +23,17 @@ func (s testRule) Apply(plan *Plan) (bool, error) {
 	return false, nil
 }
 
+type analysisMutatingTestRule struct{}
+
+func (s analysisMutatingTestRule) Name() string {
+	return "analysis_mutating"
+}
+
+func (s analysisMutatingTestRule) Apply(plan *Plan) (bool, error) {
+	plan.Query.SingleQuery.SinglePartQuery.ReadingClauses = nil
+	return true, nil
+}
+
 type testBindingLookup map[pgsql.Identifier]pgsql.DataType
 
 func (s testBindingLookup) LookupDataType(identifier pgsql.Identifier) (pgsql.DataType, bool) {
@@ -148,6 +159,79 @@ func TestOptimizerRunsRulesAndRefreshesAnalysis(t *testing.T) {
 	require.Equal(t, []RuleResult{{Name: "test", Applied: false}}, plan.Rules)
 	require.Len(t, plan.Analysis.QueryParts, 1)
 	require.Len(t, plan.Analysis.QueryParts[0].Regions, 1)
+}
+
+func TestOptimizerRefreshesAnalysisAfterAppliedMutatingRule(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
+	require.NoError(t, err)
+
+	plan, err := NewOptimizer(analysisMutatingTestRule{}).Optimize(regularQuery)
+	require.NoError(t, err)
+	require.Equal(t, []RuleResult{{
+		Name:    "analysis_mutating",
+		Applied: true,
+	}}, plan.Rules)
+	require.Len(t, plan.Analysis.QueryParts, 1)
+	require.Empty(t, plan.Analysis.QueryParts[0].Regions)
+}
+
+func TestRulePreservesAnalysis(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, rulePreservesAnalysis(PredicateAttachmentRule{}))
+	require.False(t, rulePreservesAnalysis(testRule{name: "test"}))
+}
+
+func TestExpressionReferencesAnySource(t *testing.T) {
+	t.Parallel()
+
+	variableList := cypher.NewListLiteral()
+	*variableList = append(*variableList, cypher.NewVariableWithSymbol("n"))
+
+	literalList := cypher.NewListLiteral()
+	*literalList = append(*literalList, cypher.NewLiteral(1, false))
+
+	testCases := []struct {
+		name       string
+		expression cypher.Expression
+		expected   bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:       "literal",
+			expression: cypher.NewLiteral(1, false),
+		},
+		{
+			name:       "parameter",
+			expression: cypher.NewParameter("id", nil),
+		},
+		{
+			name:       "variable",
+			expression: cypher.NewVariableWithSymbol("n"),
+			expected:   true,
+		},
+		{
+			name:       "literal list",
+			expression: literalList,
+		},
+		{
+			name:       "variable list",
+			expression: variableList,
+			expected:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, testCase.expected, expressionReferencesAnySource(testCase.expression))
+		})
+	}
 }
 
 func TestDefaultPredicateAttachmentRuleReportsSkippedWhenNoPredicatesExist(t *testing.T) {

--- a/cypher/models/pgsql/optimize/optimizer_test.go
+++ b/cypher/models/pgsql/optimize/optimizer_test.go
@@ -41,7 +41,7 @@ func (s testBindingLookup) LookupDataType(identifier pgsql.Identifier) (pgsql.Da
 	return dataType, found
 }
 
-func TestOptimizeCopiesAndAnalyzesQuery(t *testing.T) {
+func TestOptimizePreservesUnchangedQueryAndAnalyzesIt(t *testing.T) {
 	t.Parallel()
 
 	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), adcsQuery)
@@ -59,6 +59,34 @@ func TestOptimizeCopiesAndAnalyzesQuery(t *testing.T) {
 		{Name: "PredicateAttachment", Applied: true},
 	}, plan.Rules)
 	require.Len(t, plan.PredicateAttachments, 2)
+}
+
+func TestOptimizeBorrowedPreservesUnchangedQuery(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), adcsQuery)
+	require.NoError(t, err)
+
+	plan, err := OptimizeBorrowed(regularQuery)
+	require.NoError(t, err)
+	require.Same(t, regularQuery, plan.Query)
+}
+
+func TestOptimizeCopiesOnlyWhenDefaultRuleMutates(t *testing.T) {
+	t.Parallel()
+
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `
+		MATCH p = (s:User)-[:MemberOf*0..]->(g:Group)-[:AdminTo]->(d:Computer)
+		WHERE s.samaccountname =~ '(?i).*[ge]$' AND d.operatingsystem CONTAINS 'WINDOWS SERVER'
+		RETURN p
+	`)
+	require.NoError(t, err)
+
+	plan, err := OptimizeBorrowed(regularQuery)
+	require.NoError(t, err)
+	require.NotSame(t, regularQuery, plan.Query)
+	require.False(t, regularQuery.SingleQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
+	require.True(t, plan.Query.SingleQuery.SinglePartQuery.ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
 }
 
 func TestOptimizePlansADCSFanoutRewrite(t *testing.T) {
@@ -154,7 +182,9 @@ func TestOptimizerRunsRulesAndRefreshesAnalysis(t *testing.T) {
 	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
 	require.NoError(t, err)
 
-	plan, err := NewOptimizer(testRule{name: "test"}).Optimize(regularQuery)
+	plan, err := NewOptimizer(testRule{
+		name: "test",
+	}).Optimize(regularQuery)
 	require.NoError(t, err)
 	require.Equal(t, []RuleResult{{Name: "test", Applied: false}}, plan.Rules)
 	require.Len(t, plan.Analysis.QueryParts, 1)
@@ -181,7 +211,9 @@ func TestRulePreservesAnalysis(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, rulePreservesAnalysis(PredicateAttachmentRule{}))
-	require.False(t, rulePreservesAnalysis(testRule{name: "test"}))
+	require.False(t, rulePreservesAnalysis(testRule{
+		name: "test",
+	}))
 }
 
 func TestExpressionReferencesAnySource(t *testing.T) {
@@ -2304,10 +2336,13 @@ func TestInboundTraversalReversalRejectsMultiPartQueryWithoutTerminalSinglePartQ
 	require.NotEmpty(t, control.SingleQuery.MultiPartQuery.Parts)
 	require.NotNil(t, control.SingleQuery.MultiPartQuery.SinglePartQuery)
 
-	applied, err := InboundTraversalReversalRule{}.Apply(&Plan{Query: control})
+	plan := Plan{
+		Query: control,
+	}
+	applied, err := InboundTraversalReversalRule{}.Apply(&plan)
 	require.NoError(t, err)
 	require.True(t, applied)
-	require.True(t, control.SingleQuery.MultiPartQuery.Parts[0].ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
+	require.True(t, plan.Query.SingleQuery.MultiPartQuery.Parts[0].ReadingClauses[0].Match.Pattern[0].PathDirectionReversed)
 
 	// Removing the terminal single-part query models an unsupported multi-part representation, which
 	// is rejected up front so the preceding part is left untouched.
@@ -2318,7 +2353,9 @@ func TestInboundTraversalReversalRejectsMultiPartQueryWithoutTerminalSinglePartQ
 	require.NotEmpty(t, multiPartQuery.Parts)
 	multiPartQuery.SinglePartQuery = nil
 
-	applied, err = InboundTraversalReversalRule{}.Apply(&Plan{Query: regularQuery})
+	applied, err = InboundTraversalReversalRule{}.Apply(&Plan{
+		Query: regularQuery,
+	})
 	require.NoError(t, err)
 	require.False(t, applied)
 

--- a/cypher/models/pgsql/optimize/reordering.go
+++ b/cypher/models/pgsql/optimize/reordering.go
@@ -13,10 +13,19 @@ func (s ConservativePatternReorderingRule) Name() string {
 	return "ConservativePatternReordering"
 }
 
+func (s ConservativePatternReorderingRule) usesLazyCopy() bool {
+	return true
+}
+
 func (s ConservativePatternReorderingRule) Apply(plan *Plan) (bool, error) {
 	if plan == nil || plan.Query == nil || plan.Query.SingleQuery == nil {
 		return false, nil
 	}
+	if !queryWouldReorder(plan.Query, plan.Analysis) {
+		return false, nil
+	}
+
+	plan.EnsureMutable()
 
 	if plan.Query.SingleQuery.MultiPartQuery != nil {
 		return reorderMultiPartQuery(plan.Query.SingleQuery.MultiPartQuery, plan.Analysis), nil
@@ -27,6 +36,39 @@ func (s ConservativePatternReorderingRule) Apply(plan *Plan) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func queryWouldReorder(query *cypher.RegularQuery, analysis Analysis) bool {
+	if query == nil || query.SingleQuery == nil {
+		return false
+	}
+
+	if multiPart := query.SingleQuery.MultiPartQuery; multiPart != nil {
+		for partIndex, part := range multiPart.Parts {
+			if part == nil {
+				continue
+			}
+			if queryPart, ok := analysisQueryPart(analysis, partIndex); ok && readingClausesWouldReorder(part.ReadingClauses, queryPart.Regions) {
+				return true
+			}
+		}
+
+		if finalPart := multiPart.SinglePartQuery; finalPart != nil {
+			if queryPart, ok := analysisQueryPart(analysis, len(multiPart.Parts)); ok {
+				return readingClausesWouldReorder(finalPart.ReadingClauses, queryPart.Regions)
+			}
+		}
+
+		return false
+	}
+
+	if singlePart := query.SingleQuery.SinglePartQuery; singlePart != nil {
+		if queryPart, ok := analysisQueryPart(analysis, 0); ok {
+			return readingClausesWouldReorder(singlePart.ReadingClauses, queryPart.Regions)
+		}
+	}
+
+	return false
 }
 
 type reorderCandidate struct {
@@ -92,9 +134,22 @@ func reorderReadingClauses(readingClauses []*cypher.ReadingClause, regions []Reg
 	return applied
 }
 
+func readingClausesWouldReorder(readingClauses []*cypher.ReadingClause, regions []Region) bool {
+	for _, region := range regions {
+		if region.StartClause < 0 || region.EndClause >= len(readingClauses) || region.StartClause >= region.EndClause {
+			continue
+		}
+
+		if reorderRegionWouldApply(readingClauses[region.StartClause:region.EndClause+1], declaredBeforeClause(readingClauses, region.StartClause)) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func reorderRegion(regionClauses []*cypher.ReadingClause, declaredBeforeRegion map[string]struct{}) bool {
 	candidates := reorderCandidates(regionClauses, declaredBeforeRegion)
-
 	reordered := reorderCandidateSegments(candidates, declaredBeforeRegion)
 
 	var applied bool
@@ -106,6 +161,19 @@ func reorderRegion(regionClauses []*cypher.ReadingClause, declaredBeforeRegion m
 	}
 
 	return applied
+}
+
+func reorderRegionWouldApply(regionClauses []*cypher.ReadingClause, declaredBeforeRegion map[string]struct{}) bool {
+	candidates := reorderCandidates(regionClauses, declaredBeforeRegion)
+	reordered := reorderCandidateSegments(candidates, declaredBeforeRegion)
+
+	for idx, candidate := range reordered {
+		if regionClauses[idx] != candidate.clause {
+			return true
+		}
+	}
+
+	return false
 }
 
 func declaredBeforeClause(readingClauses []*cypher.ReadingClause, clauseIndex int) map[string]struct{} {


### PR DESCRIPTION
## Description

Reduces avoidable PostgreSQL optimizer work during translation. 

Translation appears in a high-frequency query path. The prior behavior
repeatedly analyzed and copied simple traversal queries even when no rule
changed them. This lowers that fixed per-translation cost without changing
generated query semantics.

- Skip the predicate-attachment analysis pass when it is not needed.
- Re-run analysis for reordering rules only after they mutate the AST.
- Defer copying the Cypher AST until an optimizer rule actually mutates it.

Resolves: BED-9469

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature / enhancement (a change that adds new functionality)
- [x] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved query optimization efficiency by avoiding unnecessary query copies and repeated predicate analysis.
  * Added support for optimizing borrowed queries while preserving unchanged query instances.
  * Added optimizer benchmarks for representative queries.

* **Bug Fixes**
  * Improved safety when reversing traversal directions and reordering query regions.
  * Ensured optimizer analysis is refreshed after changes that modify query structure.
  * Preserved unsupported query representations without altering them.

* **Tests**
  * Expanded coverage for query identity, mutation behavior, analysis refresh, and source-reference detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->