### PR TITLE
feat: add translation policies and parameter provenance - BED-9469

### DIFF
--- a/cypher/models/cypher/format/format.go
+++ b/cypher/models/cypher/format/format.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/walk"
 
 	"github.com/specterops/dawgs/graph"
 )
@@ -1217,9 +1218,51 @@ func (s Emitter) Write(regularQuery *cypher.RegularQuery, writer io.Writer) erro
 }
 
 func RegularQuery(query *cypher.RegularQuery, stripLiterals bool) (string, error) {
+	return regularQuery(query, NewCypherEmitter(stripLiterals))
+}
+
+// RegularQueryWithParameterSequence formats a regular query with deterministic
+// parameter names by structural occurrence while leaving the source tree
+// unchanged.
+func RegularQueryWithParameterSequence(query *cypher.RegularQuery, stripLiterals bool, parameterSequence []string) (string, error) {
+	owned := cypher.Copy(query)
+	rewriter := parameterSequenceRewriter{
+		Visitor: walk.NewVisitor[cypher.SyntaxNode](),
+		symbols: parameterSequence,
+	}
+	if err := walk.Cypher(owned, &rewriter); err != nil {
+		return "", err
+	} else if rewriter.index != len(rewriter.symbols) {
+		return "", fmt.Errorf("parameter sequence has more symbols than query parameters")
+	}
+
+	return RegularQuery(owned, stripLiterals)
+}
+
+type parameterSequenceRewriter struct {
+	walk.Visitor[cypher.SyntaxNode]
+	symbols []string
+	index   int
+}
+
+func (s *parameterSequenceRewriter) Enter(node cypher.SyntaxNode) {
+	parameter, isParameter := node.(*cypher.Parameter)
+	if !isParameter {
+		return
+	}
+	if s.index == len(s.symbols) {
+		s.SetErrorf("parameter sequence has fewer symbols than query parameters")
+		return
+	}
+
+	parameter.Symbol = s.symbols[s.index]
+	s.index++
+}
+
+func regularQuery(query *cypher.RegularQuery, emitter Emitter) (string, error) {
 	buffer := &bytes.Buffer{}
 
-	if err := NewCypherEmitter(stripLiterals).Write(query, buffer); err != nil {
+	if err := emitter.Write(query, buffer); err != nil {
 		return "", err
 	} else {
 		return buffer.String(), nil

--- a/cypher/models/cypher/format/format_test.go
+++ b/cypher/models/cypher/format/format_test.go
@@ -44,6 +44,30 @@ func TestCypherEmitter_FormatsMapLiteralInKeyOrder(t *testing.T) {
 	require.Equal(t, "{a: 1, b: 2}", buffer.String())
 }
 
+func TestRegularQueryWithParameterSequenceFormatsWithoutMutatingInput(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "match (n) where n.first = $value and n.second = $value return n")
+	require.NoError(t, err)
+
+	formatted, err := format.RegularQueryWithParameterSequence(regularQuery, false, []string{"first", "second"})
+	require.NoError(t, err)
+	require.Equal(t, "match (n) where n.first = $first and n.second = $second return n", formatted)
+
+	original, err := format.RegularQuery(regularQuery, false)
+	require.NoError(t, err)
+	require.Equal(t, "match (n) where n.first = $value and n.second = $value return n", original)
+}
+
+func TestRegularQueryWithParameterSequenceRejectsMismatchedSymbols(t *testing.T) {
+	regularQuery, err := frontend.ParseCypher(frontend.NewContext(), "return $value")
+	require.NoError(t, err)
+
+	_, err = format.RegularQueryWithParameterSequence(regularQuery, false, nil)
+	require.ErrorContains(t, err, "fewer symbols")
+
+	_, err = format.RegularQueryWithParameterSequence(regularQuery, false, []string{"first", "second"})
+	require.ErrorContains(t, err, "more symbols")
+}
+
 func TestCypherEmitter_FormatsMapLiteralPropertyKeys(t *testing.T) {
 	var (
 		buffer  = &bytes.Buffer{}

--- a/cypher/models/pgsql/translate/translator.go
+++ b/cypher/models/pgsql/translate/translator.go
@@ -17,18 +17,55 @@ import (
 // exercise translation output).
 const DefaultGraphID int32 = 0
 
+// OptimizerMode controls whether PostgreSQL-specific rewrites and lowering
+// decisions are applied during translation. Disabled mode remains a semantic
+// fallback: it translates the original AST with an empty lowering plan.
+type OptimizerMode string
+
+const (
+	OptimizerEnabled  OptimizerMode = "enabled"
+	OptimizerDisabled OptimizerMode = "disabled"
+)
+
+func (s OptimizerMode) Valid() bool {
+	return s == OptimizerEnabled || s == OptimizerDisabled
+}
+
+// Options configures a translation without changing the default Translate API.
+type Options struct {
+	OptimizerMode OptimizerMode
+}
+
+func DefaultOptions() Options {
+	return Options{
+		OptimizerMode: OptimizerEnabled,
+	}
+}
+
+func (s Options) normalized() (Options, error) {
+	if s.OptimizerMode == "" {
+		s.OptimizerMode = OptimizerEnabled
+	}
+	if !s.OptimizerMode.Valid() {
+		return Options{}, fmt.Errorf("unsupported PostgreSQL optimizer mode %q", s.OptimizerMode)
+	}
+
+	return s, nil
+}
+
 type Translator struct {
 	walk.Visitor[cypher.SyntaxNode]
 
-	ctx            context.Context
-	kindMapper     *contextAwareKindMapper
-	graphID        int32
-	parameters     map[string]any
-	translation    Result
-	treeTranslator *ExpressionTreeTranslator
-	query          *Query
-	scope          *Scope
-	unwindTargets  map[*cypher.Variable]struct{}
+	ctx              context.Context
+	kindMapper       *contextAwareKindMapper
+	graphID          int32
+	parameters       map[string]any
+	translation      Result
+	parameterSources map[string]string
+	treeTranslator   *ExpressionTreeTranslator
+	query            *Query
+	scope            *Scope
+	unwindTargets    map[*cypher.Variable]struct{}
 
 	collectIDMembershipAliases map[pgsql.Identifier]struct{}
 	collectIDProjectionDepth   int
@@ -63,6 +100,7 @@ func NewTranslator(ctx context.Context, kindMapper pgsql.KindMapper, parameters 
 
 	var (
 		translatedParameters = map[string]any{}
+		parameterSources     = map[string]string{}
 		ctxAwareKindMapper   = newContextAwareKindMapper(ctx, kindMapper, translatedParameters)
 	)
 
@@ -71,14 +109,15 @@ func NewTranslator(ctx context.Context, kindMapper pgsql.KindMapper, parameters 
 		translation: Result{
 			Parameters: translatedParameters,
 		},
-		ctx:            ctx,
-		kindMapper:     ctxAwareKindMapper,
-		graphID:        graphID,
-		parameters:     inputParameters,
-		treeTranslator: NewExpressionTreeTranslator(ctxAwareKindMapper),
-		query:          &Query{},
-		scope:          NewScope(),
-		unwindTargets:  map[*cypher.Variable]struct{}{},
+		ctx:              ctx,
+		kindMapper:       ctxAwareKindMapper,
+		graphID:          graphID,
+		parameters:       inputParameters,
+		parameterSources: parameterSources,
+		treeTranslator:   NewExpressionTreeTranslator(ctxAwareKindMapper),
+		query:            &Query{},
+		scope:            NewScope(),
+		unwindTargets:    map[*cypher.Variable]struct{}{},
 	}
 }
 
@@ -227,6 +266,7 @@ func (s *Translator) Enter(expression cypher.SyntaxNode) {
 				} else {
 					// Lift the parameter value into the parameters map
 					s.translation.Parameters[parameterBinding.Identifier.String()] = negotiatedValue
+					s.parameterSources[parameterBinding.Identifier.String()] = typedExpression.Symbol
 					parameterBinding.Parameter = newParameter
 				}
 
@@ -672,7 +712,9 @@ func (s *Translator) recordLowering(name string) {
 		}
 	}
 
-	s.translation.Optimization.Lowerings = append(s.translation.Optimization.Lowerings, optimize.LoweringDecision{Name: name})
+	s.translation.Optimization.Lowerings = append(s.translation.Optimization.Lowerings, optimize.LoweringDecision{
+		Name: name,
+	})
 }
 
 func (s *Translator) appliedLoweringCountSnapshot() map[string]int {
@@ -804,14 +846,46 @@ func skippedTraversalDirectionReason(plan optimize.LoweringPlan) string {
 }
 
 func Translate(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32) (Result, error) {
-	optimizedPlan, err := optimize.Optimize(cypherQuery)
+	return TranslateWithOptions(ctx, cypherQuery, kindMapper, parameters, graphID, DefaultOptions())
+}
+
+// TranslateWithOptions translates Cypher with an explicit optimizer policy.
+func TranslateWithOptions(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32, options Options) (Result, error) {
+	translation, _, err := translateWithOptions(ctx, cypherQuery, kindMapper, parameters, graphID, options, false)
+	return translation, err
+}
+
+// TranslateWithOptionsAndParameterSources translates Cypher and returns the
+// generated-parameter provenance required to safely rebind a cached result.
+// The input tree is borrowed: it is copied only if an optimizer rule mutates
+// it. This is intended for compilation code that owns the input tree.
+func TranslateWithOptionsAndParameterSources(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32, options Options) (Result, map[string]string, error) {
+	return translateWithOptions(ctx, cypherQuery, kindMapper, parameters, graphID, options, true)
+}
+
+func translateWithOptions(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper pgsql.KindMapper, parameters map[string]any, graphID int32, options Options, borrowQuery bool) (Result, map[string]string, error) {
+	options, err := options.normalized()
 	if err != nil {
-		return Result{}, err
+		return Result{}, nil, err
+	}
+
+	var optimizedPlan optimize.Plan
+	if options.OptimizerMode == OptimizerEnabled {
+		if borrowQuery {
+			optimizedPlan, err = optimize.OptimizeBorrowed(cypherQuery)
+		} else {
+			optimizedPlan, err = optimize.Optimize(cypherQuery)
+		}
+		if err != nil {
+			return Result{}, nil, err
+		}
+	} else {
+		optimizedPlan.Query = cypherQuery
 	}
 
 	translator := NewTranslator(ctx, kindMapper, parameters, graphID)
 	if membershipAliases, err := collectIDMembershipAliases(optimizedPlan.Query); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	} else {
 		translator.collectIDMembershipAliases = membershipAliases
 	}
@@ -825,25 +899,25 @@ func Translate(ctx context.Context, cypherQuery *cypher.RegularQuery, kindMapper
 	}
 
 	if translated, err := translator.translateCountStoreFastPath(optimizedPlan.Query, optimizedPlan.LoweringPlan); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	} else if translated {
 		translator.recordSkippedLowerings()
-		return translator.translation, nil
+		return translator.translation, translator.parameterSources, nil
 	}
 
 	if translated, err := translator.translateAggregateTraversalCount(optimizedPlan.Query, optimizedPlan.LoweringPlan); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	} else if translated {
 		translator.recordSkippedLowerings()
-		return translator.translation, nil
+		return translator.translation, translator.parameterSources, nil
 	}
 
 	if err := walk.Cypher(optimizedPlan.Query, translator); err != nil {
-		return Result{}, err
+		return Result{}, nil, err
 	}
 
 	translator.recordSkippedLowerings()
-	return translator.translation, nil
+	return translator.translation, translator.parameterSources, nil
 }
 
 func decodeCypherStringLiteral(raw string) (string, error) {

--- a/cypher/models/pgsql/translate/translator_test.go
+++ b/cypher/models/pgsql/translate/translator_test.go
@@ -1,11 +1,66 @@
 package translate
 
 import (
+	"context"
 	"testing"
 
+	"github.com/specterops/dawgs/cypher/frontend"
+	"github.com/specterops/dawgs/drivers/pg/pgutil"
+	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTranslationRecordsNamedParameterSources(t *testing.T) {
+	kindMapper := pgutil.NewInMemoryKindMapper()
+	kindMapper.Put(graph.StringKind("NodeKind1"))
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n:NodeKind1) WHERE n.name = $needle RETURN n`)
+	require.NoError(t, err)
+
+	translation, sources, err := TranslateWithOptionsAndParameterSources(context.Background(), query, kindMapper, map[string]any{"needle": "first"}, DefaultGraphID, DefaultOptions())
+	require.NoError(t, err)
+	require.Len(t, translation.Parameters, 1)
+	require.Len(t, sources, 1)
+	for generated := range translation.Parameters {
+		require.Equal(t, "needle", sources[generated])
+	}
+}
+
+func TestTranslateWithDisabledOptimizerUsesGenericPlan(t *testing.T) {
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
+	require.NoError(t, err)
+
+	translation, err := TranslateWithOptions(
+		context.Background(),
+		query,
+		pgutil.NewInMemoryKindMapper(),
+		nil,
+		DefaultGraphID,
+		Options{
+			OptimizerMode: OptimizerDisabled,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, translation.Optimization.Rules)
+	require.Nil(t, translation.Optimization.LoweringPlan)
+}
+
+func TestTranslateWithOptionsRejectsUnknownOptimizerMode(t *testing.T) {
+	query, err := frontend.ParseCypher(frontend.NewContext(), `MATCH (n) RETURN n`)
+	require.NoError(t, err)
+
+	_, err = TranslateWithOptions(
+		context.Background(),
+		query,
+		pgutil.NewInMemoryKindMapper(),
+		nil,
+		DefaultGraphID,
+		Options{
+			OptimizerMode: "unknown",
+		},
+	)
+	require.ErrorContains(t, err, "unsupported PostgreSQL optimizer mode")
+}
 
 func TestDecodeCypherStringLiteral(t *testing.T) {
 	t.Parallel()

--- a/query/rewrite.go
+++ b/query/rewrite.go
@@ -3,9 +3,8 @@ package query
 import (
 	"strconv"
 
-	"github.com/specterops/dawgs/cypher/models/walk"
-
 	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/cypher/models/walk"
 )
 
 type ParameterRewriter struct {
@@ -13,6 +12,19 @@ type ParameterRewriter struct {
 
 	Parameters     map[string]any
 	parameterIndex int
+	prefix         string
+}
+
+// ParameterNamer deterministically assigns names to parameters without
+// mutating the Cypher tree. It is useful to adapters that need a stable query
+// identity before deciding whether an owned copy is necessary.
+type ParameterNamer struct {
+	walk.Visitor[cypher.SyntaxNode]
+
+	Parameters     map[string]any
+	Symbols        []string
+	parameterIndex int
+	prefix         string
 }
 
 func NewParameterRewriter() *ParameterRewriter {
@@ -20,6 +32,28 @@ func NewParameterRewriter() *ParameterRewriter {
 		Visitor:        walk.NewVisitor[cypher.SyntaxNode](),
 		Parameters:     map[string]any{},
 		parameterIndex: 0,
+		prefix:         "p",
+	}
+}
+
+// NewParameterRewriterWithPrefix returns a rewriter whose generated names are
+// scoped to prefix. Adapters use this to distinguish builder-owned values from
+// caller supplied Cypher parameters.
+func NewParameterRewriterWithPrefix(prefix string) *ParameterRewriter {
+	rewriter := NewParameterRewriter()
+	rewriter.prefix = prefix
+	return rewriter
+}
+
+// NewParameterNamerWithPrefix returns a read-only parameter namer whose
+// generated names are scoped to prefix.
+func NewParameterNamerWithPrefix(prefix string) *ParameterNamer {
+	return &ParameterNamer{
+		Visitor:        walk.NewVisitor[cypher.SyntaxNode](),
+		Parameters:     map[string]any{},
+		Symbols:        []string{},
+		parameterIndex: 0,
+		prefix:         prefix,
 	}
 }
 
@@ -28,7 +62,7 @@ func (s *ParameterRewriter) Enter(node cypher.SyntaxNode) {
 	case *cypher.Parameter:
 		var (
 			nextParameterIndex    = s.parameterIndex
-			nextParameterIndexStr = "p" + strconv.Itoa(nextParameterIndex)
+			nextParameterIndexStr = s.prefix + strconv.Itoa(nextParameterIndex)
 		)
 
 		// Increment the parameter index first
@@ -37,5 +71,15 @@ func (s *ParameterRewriter) Enter(node cypher.SyntaxNode) {
 		// Record the parameter in our map and then bind the symbol in the model
 		s.Parameters[nextParameterIndexStr] = typedNode.Value
 		typedNode.Symbol = nextParameterIndexStr
+	}
+}
+
+func (s *ParameterNamer) Enter(node cypher.SyntaxNode) {
+	switch typedNode := node.(type) {
+	case *cypher.Parameter:
+		name := s.prefix + strconv.Itoa(s.parameterIndex)
+		s.parameterIndex++
+		s.Parameters[name] = typedNode.Value
+		s.Symbols = append(s.Symbols, name)
 	}
 }

--- a/query/rewrite_fuzz_test.go
+++ b/query/rewrite_fuzz_test.go
@@ -1,0 +1,70 @@
+package query
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	cypherFormat "github.com/specterops/dawgs/cypher/models/cypher/format"
+	"github.com/specterops/dawgs/cypher/models/walk"
+)
+
+// FuzzParameterNamerAndRewriterAgree protects the positional provenance used
+// by PostgreSQL builder-query caching. The non-mutating naming pass and the
+// rewriting pass must assign identical symbols and values in structural order.
+func FuzzParameterNamerAndRewriterAgree(f *testing.F) {
+	f.Add(int64(101), int64(202), int64(303))
+	f.Add(int64(-1), int64(0), int64(1))
+
+	f.Fuzz(func(t *testing.T, first, second, third int64) {
+		builder := NewBuilder(nil)
+		builder.Apply(
+			Where(And(
+				Equals(NodeProperty("first"), first),
+				Or(
+					GreaterThan(NodeProperty("second"), second),
+					LessThan(NodeProperty("third"), third),
+				),
+			)),
+			Returning(Node()),
+		)
+		regularQuery, err := builder.Build(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		namer := NewParameterNamerWithPrefix("fuzz_p")
+		if err := walk.Cypher(regularQuery, namer); err != nil {
+			t.Fatal(err)
+		}
+		namedSource, err := cypherFormat.RegularQueryWithParameterSequence(regularQuery, false, namer.Symbols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		owned := cypher.Copy(regularQuery)
+		rewriter := NewParameterRewriterWithPrefix("fuzz_p")
+		if err := walk.Cypher(owned, rewriter); err != nil {
+			t.Fatal(err)
+		}
+		rewrittenSource, err := cypherFormat.RegularQuery(owned, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if namedSource != rewrittenSource {
+			t.Fatalf("parameter naming diverged:\nnamed: %s\nrewritten: %s", namedSource, rewrittenSource)
+		}
+		if !reflect.DeepEqual(namer.Parameters, rewriter.Parameters) {
+			t.Fatalf("parameter values diverged: named=%v rewritten=%v", namer.Parameters, rewriter.Parameters)
+		}
+
+		originalSource, err := cypherFormat.RegularQuery(regularQuery, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if originalSource == rewrittenSource {
+			t.Fatal("parameter rewrite unexpectedly mutated the builder-owned query")
+		}
+	})
+}


### PR DESCRIPTION
## Description

Adds the translation primitives required to safely reuse PostgreSQL translations.

A cache can only reuse a compiled translation when it can rebuild the correct runtime parameter
values. Parameter provenance records that relationship, while the policy makes optimized and
baseline translation behavior explicit.

- Introduces explicit translation policy control.
- Preserves the provenance of generated parameters.
- Adds non-mutating parameter naming for repeatable query normalization.
- Covers translation and query-rewrite behavior with unit and fuzz tests.

Resolves: BED-9469

## Type of Change

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature / enhancement (a change that adds new functionality)
- [ ] Refactor (no behaviour change)
- [ ] Test coverage
- [ ] Build / CI / tooling
- [ ] Documentation

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Full test suite run (`make test_all` with `CONNECTION_STRING` set)

## Screenshots (if appropriate):

## Driver Impact

<!-- Does this change affect a specific backend? -->

- [x] PostgreSQL driver (`drivers/pg`)
- [ ] Neo4j driver (`drivers/neo4j`)

## Checklist

- [x] Code is formatted
- [x] All existing tests pass
- [x] `go.mod` / `go.sum` are up to date if dependencies changed

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for formatting queries with custom parameter sequences while preserving the original query.
  * Added configurable PostgreSQL optimizer modes, including enabled and disabled options.
  * Added parameter-source reporting to help identify the origin of generated parameters.
  * Added configurable prefixes for generated parameter names, with `p` as the default.

* **Bug Fixes**
  * Added validation for mismatched parameter counts and unsupported optimizer modes.
  * Improved consistency between parameter naming and query rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->